### PR TITLE
zincati: add agent identity

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,44 @@
+//! Configuration parsing and validation.
+//!
+//! This module contains the following logical entities:
+//!  * Fragments: TOML configuration entries.
+//!  * Inputs: configuration fragments merged, but not yet validated.
+//!  * Settings: validated settings for the agent.
+
+use crate::identity::Identity;
+use failure::{Fallible, ResultExt};
+use log::debug;
+use serde::Serialize;
+
+/// Runtime configuration for the agent.
+///
+/// It holds validated agent configuration.
+#[derive(Debug, Serialize)]
+pub(crate) struct Settings {
+    pub(crate) identity: Identity,
+}
+
+impl Settings {
+    /// Assemble runtime settings.
+    pub(crate) fn assemble() -> Fallible<Self> {
+        /*
+        let dirs = vec!["/usr/lib", "/run", "/etc"];
+        let cfg = ConfigInput::read_configs(&dirs, crate_name!())?;
+        */
+        Self::validate(())
+    }
+
+    /// Validate config and return a valid agent settings.
+    fn validate(_cfg: ()) -> Fallible<Self> {
+        /*
+        let identity = Identity::with_config(cfg.identity)?;
+         */
+        let identity =
+            Identity::try_default().context("failed to validate agent identity configuration")?;
+
+        let settings = Self { identity };
+        debug!("runtime settings: {:?}", settings);
+
+        Ok(settings)
+    }
+}

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -1,0 +1,98 @@
+use failure::{Fallible, ResultExt};
+use serde::Serialize;
+use uuid::Uuid;
+
+/// Default group for reboot management.
+static DEFAULT_GROUP: &str = "default";
+
+/// Agent identity.
+#[derive(Debug, Serialize)]
+pub(crate) struct Identity {
+    /// OS base architecture.
+    pub(crate) basearch: String,
+    /// Current OS version.
+    pub(crate) current_version: String,
+    /// Update groupd.
+    pub(crate) group: String,
+    /// Unique node identifier.
+    pub(crate) node_uuid: Uuid,
+    /// OS platform.
+    pub(crate) platform: String,
+    /// Stream label.
+    pub(crate) stream: String,
+    /// Optional throttle level, 0 (never) to 1000 (unlimited).
+    pub(crate) throttle_permille: Option<u16>,
+}
+
+impl Identity {
+    /*
+    pub(crate) fn with_config(cfg: IdentityInput) -> Fallible<Self> {
+        let mut id = Self::try_default().context("failed to build default identity")?;
+
+        if !cfg.group.is_empty() {
+            id.group = cfg.group;
+        };
+
+        if !cfg.node_uuid.is_empty() {
+            id.node_uuid = Uuid::parse_str(&cfg.node_uuid).context("failed to parse uuid")?;
+        }
+
+        if let Some(tp) = cfg.throttle_permille {
+            id.throttle_permille = Some(tp);
+        }
+
+        Ok(id)
+    }
+    */
+
+    /// Try to build default agent identity.
+    pub fn try_default() -> Fallible<Self> {
+        // TODO(lucab): populate these.
+        let basearch = read_basearch()?;
+        let stream = read_stream()?;
+        let platform = read_platform_id()?;
+        let node_uuid = compute_node_uuid()?;
+        let current_version = read_os_version().context("failed to get current OS version")?;
+
+        let id = Self {
+            basearch,
+            stream,
+            platform,
+            current_version,
+            group: DEFAULT_GROUP.to_string(),
+            node_uuid,
+            throttle_permille: None,
+        };
+        Ok(id)
+    }
+}
+
+fn read_stream() -> Fallible<String> {
+    // TODO(lucab): read this from os-release.
+    let ver = "stable".to_string();
+    Ok(ver)
+}
+
+fn read_platform_id() -> Fallible<String> {
+    // TODO(lucab): read this from kernel command-line.
+    let ver = "metal-bios".to_string();
+    Ok(ver)
+}
+
+fn read_basearch() -> Fallible<String> {
+    // TODO(lucab): read this from os-release.
+    let ver = "amd64".to_string();
+    Ok(ver)
+}
+
+fn read_os_version() -> Fallible<String> {
+    // TODO(lucab): read this from os-release.
+    let ver = "FCOS-01".to_string();
+    Ok(ver)
+}
+
+fn compute_node_uuid() -> Fallible<Uuid> {
+    // TODO(lucab): hash machine-id.
+    let node_uuid = Uuid::from_u128(0);
+    Ok(node_uuid)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,10 @@
 
 /// Command-line options.
 mod cli;
+/// File-based configuration.
+mod config;
+/// Agent identity.
+mod identity;
 
 use failure::ResultExt;
 use log::{debug, info, trace};
@@ -36,6 +40,10 @@ fn run_agent() -> failure::Fallible<()> {
         crate_name!(),
         crate_version!()
     );
+
+    let settings =
+        config::Settings::assemble().context("failed to assemble configuration settings")?;
+    info!("node identity: {:?}", settings.identity);
 
     trace!("creating actor system");
     let sys = actix::System::new(crate_name!());


### PR DESCRIPTION
This adds a skeleton for runtime agent identity.