### PR TITLE
strategy: add immediate mode

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,6 +12,7 @@ mod fragments;
 pub(crate) mod inputs;
 
 use crate::identity::Identity;
+use crate::strategy::UpdateStrategy;
 use failure::{Fallible, ResultExt};
 use serde::Serialize;
 use structopt::clap::crate_name;
@@ -21,7 +22,10 @@ use structopt::clap::crate_name;
 /// It holds validated agent configuration.
 #[derive(Debug, Serialize)]
 pub(crate) struct Settings {
+    /// Agent configuration.
     pub(crate) identity: Identity,
+    /// Agent update strategy.
+    pub(crate) strategy: UpdateStrategy,
 }
 
 impl Settings {
@@ -36,7 +40,9 @@ impl Settings {
     fn validate(cfg: inputs::ConfigInput) -> Fallible<Self> {
         let identity = Identity::with_config(cfg.identity)
             .context("failed to validate agent identity configuration")?;
+        let strategy = UpdateStrategy::with_config(cfg.updates)
+            .context("failed to validate agent updates configuration")?;
 
-        Ok(Self { identity })
+        Ok(Self { identity, strategy })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ mod cli;
 mod config;
 /// Agent identity.
 mod identity;
+/// Update strategies.
+mod strategy;
 
 use failure::ResultExt;
 use log::{debug, info, trace};

--- a/src/strategy/immediate.rs
+++ b/src/strategy/immediate.rs
@@ -1,0 +1,69 @@
+//! Strategy for immediate updates.
+
+#![allow(unused)]
+
+use crate::config::inputs::StratImmediateInput;
+use failure::{Error, Fallible};
+use futures::future;
+use futures::prelude::*;
+use log::trace;
+use serde::Serialize;
+
+/// Strategy for immediate updates.
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct StrategyImmediate {
+    /// Whether to check for and fetch updates.
+    check: bool,
+    /// Whether to finalize updates.
+    finalize: bool,
+}
+
+impl StrategyImmediate {
+    /// Try to parse strategy configuration.
+    pub(crate) fn with_config(cfg: StratImmediateInput) -> Fallible<Self> {
+        let mut immediate = Self::default();
+
+        if let Some(check) = cfg.fetch_updates {
+            immediate.check = check;
+        }
+        if let Some(finalize) = cfg.finalize_updates {
+            immediate.finalize = finalize;
+        }
+
+        Ok(immediate)
+    }
+
+    /// Check if finalization is allowed.
+    pub(crate) fn can_finalize(&self) -> impl Future<Item = bool, Error = Error> {
+        trace!(
+            "immediate strategy, can finalize updates: {}",
+            self.finalize
+        );
+
+        let immediate = future::ok(self.finalize);
+        Box::new(immediate)
+    }
+
+    pub(crate) fn report_steady(&self) -> Box<Future<Item = bool, Error = Error>> {
+        trace!("immediate strategy, report steady: {}", true);
+
+        let immediate = future::ok(true);
+        Box::new(immediate)
+    }
+
+    pub(crate) fn can_check_and_fetch(&self) -> Box<Future<Item = bool, Error = Error>> {
+        trace!("immediate strategy, can check updates: {}", self.check);
+
+        let immediate = future::ok(self.check);
+        Box::new(immediate)
+    }
+}
+
+impl Default for StrategyImmediate {
+    fn default() -> Self {
+        Self {
+            check: true,
+            finalize: true,
+        }
+    }
+}

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -1,0 +1,78 @@
+//! Update and reboot strategies.
+
+#![allow(unused)]
+
+use crate::config::inputs;
+use crate::identity::Identity;
+use failure::{bail, Fallible};
+use futures::prelude::*;
+use log::error;
+use serde::Serialize;
+
+mod immediate;
+pub(crate) use immediate::StrategyImmediate;
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) enum UpdateStrategy {
+    Immediate(StrategyImmediate),
+}
+
+impl UpdateStrategy {
+    /// Try to parse config inputs into a valid strategy.
+    pub(crate) fn with_config(cfg: inputs::UpdateInput) -> Fallible<Self> {
+        let strategy = match cfg.strategy.as_ref() {
+            "immediate" => UpdateStrategy::try_immediate(cfg.immediate)?,
+            "" => UpdateStrategy::default(),
+            x => bail!("unsupported strategy '{}'", x),
+        };
+        Ok(strategy)
+    }
+
+    /// Check if finalization is allowed at this time.
+    pub(crate) fn can_finalize(
+        &self,
+        _identity: &Identity,
+    ) -> Box<Future<Item = bool, Error = ()>> {
+        let lock = match self {
+            UpdateStrategy::Immediate(i) => i.can_finalize(),
+        }
+        .map_err(|e| error!("{}", e));
+        Box::new(lock)
+    }
+
+    /// Try to report and enter steady state.
+    pub(crate) fn report_steady(
+        &self,
+        _identity: &Identity,
+    ) -> Box<Future<Item = bool, Error = ()>> {
+        let unlock = match self {
+            UpdateStrategy::Immediate(i) => i.report_steady(),
+        }
+        .map_err(|e| error!("{}", e));
+        Box::new(unlock)
+    }
+
+    /// Check if this agent is allowed to check for updates at this time.
+    pub(crate) fn can_check_and_fetch(
+        &self,
+        _identity: &Identity,
+    ) -> Box<Future<Item = bool, Error = ()>> {
+        let can_check = match self {
+            UpdateStrategy::Immediate(i) => i.can_check_and_fetch(),
+        }
+        .map_err(|e| error!("{}", e));
+        Box::new(can_check)
+    }
+
+    fn try_immediate(cfg: inputs::StratImmediateInput) -> Fallible<Self> {
+        let immediate = StrategyImmediate::with_config(cfg)?;
+        Ok(UpdateStrategy::Immediate(immediate))
+    }
+}
+
+impl Default for UpdateStrategy {
+    fn default() -> Self {
+        let immediate = StrategyImmediate::default();
+        UpdateStrategy::Immediate(immediate)
+    }
+}


### PR DESCRIPTION
This adds update-strategy settings and "immediate" mode.
Immediate is the default update strategy. It fetches and
finalizes new updates immediately, regardless of maintenance
windows or cluster-wide orchestration.
It optionally allows to disable fetching or finalizing via
dedicated config options.