### PR TITLE
zincati: add agent state-machine

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,10 @@ mod config;
 mod identity;
 /// Update strategies.
 mod strategy;
+/// Update agent.
+mod update_agent;
 
+use actix::Actor;
 use failure::ResultExt;
 use log::{debug, info, trace};
 use structopt::clap::{crate_name, crate_version};
@@ -54,7 +57,10 @@ fn run_agent() -> failure::Fallible<()> {
     trace!("creating actor system");
     let sys = actix::System::new(crate_name!());
 
-    // TODO(lucab): parse configuration files and run agent.
+    trace!("creating update agent");
+    let agent = update_agent::UpdateAgent::with_config(settings)
+        .context("failed to assemble update-agent from configuration settings")?;
+    let _addr = agent.start();
 
     debug!("starting actor system");
     sys.run().context("agent failed")?;

--- a/src/update_agent/actor.rs
+++ b/src/update_agent/actor.rs
@@ -1,0 +1,111 @@
+//! Update agent actor.
+
+use super::{UpdateAgent, UpdateAgentState};
+use actix::prelude::*;
+use failure::Error;
+use log::trace;
+
+impl Actor for UpdateAgent {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        trace!("update agent started");
+
+        // Kick-start the state machine.
+        Self::tick_now(ctx);
+    }
+}
+
+pub(crate) struct RefreshTick {}
+
+impl Message for RefreshTick {
+    type Result = Result<(), Error>;
+}
+
+impl Handler<RefreshTick> for UpdateAgent {
+    type Result = ResponseActFuture<Self, (), Error>;
+
+    fn handle(&mut self, _msg: RefreshTick, ctx: &mut Self::Context) -> Self::Result {
+        trace!("update agent tick, current state: {:?}", self.state);
+        let prev_state = self.state.clone();
+
+        let state_action = match self.state {
+            UpdateAgentState::StartState => self.initialize(),
+            UpdateAgentState::Initialized => self.try_steady(),
+            UpdateAgentState::Steady => self.try_check_updates(),
+            UpdateAgentState::_EndState => self.nop(),
+        };
+
+        let update_machine = state_action.map(move |_r, actor, ctx| {
+            if prev_state != actor.state {
+                let now = chrono::Utc::now();
+                actor.state_changed = now;
+                Self::tick_now(ctx);
+            } else {
+                Self::tick_later(ctx, actor.refresh_period);
+            }
+        });
+
+        // Process state machine refresh ticks sequentially.
+        ctx.wait(update_machine);
+
+        Box::new(actix::fut::ok(()))
+    }
+}
+
+impl UpdateAgent {
+    /// Schedule an immediate refresh the state machine.
+    pub fn tick_now(ctx: &mut Context<Self>) {
+        ctx.notify(RefreshTick {})
+    }
+
+    /// Schedule a delayed refresh of the state machine.
+    pub fn tick_later(ctx: &mut Context<Self>, after: std::time::Duration) -> actix::SpawnHandle {
+        ctx.notify_later(RefreshTick {}, after)
+    }
+
+    /// Initialize the update agent.
+    fn initialize(&mut self) -> ResponseActFuture<Self, (), ()> {
+        trace!("update agent in start state");
+
+        let initialization = self.nop().map(|_r, actor, _ctx| {
+            actor.state.initialized();
+        });
+
+        Box::new(initialization)
+    }
+
+    /// Try to reach steady state.
+    fn try_steady(&mut self) -> ResponseActFuture<Self, (), ()> {
+        trace!("trying to report steady state");
+
+        let report_steady = self.strategy.report_steady(&self.identity);
+        let state_change =
+            actix::fut::wrap_future::<_, Self>(report_steady).map(|is_steady, actor, _ctx| {
+                actor.state.steady(is_steady);
+            });
+
+        Box::new(state_change)
+    }
+
+    /// Try to check for and stage updates.
+    fn try_check_updates(&mut self) -> ResponseActFuture<Self, (), ()> {
+        trace!("trying to check for updates");
+
+        let can_check = self.strategy.can_check_and_fetch(&self.identity);
+        let state_change =
+            actix::fut::wrap_future::<_, Self>(can_check).map(|can_check, _actor, _ctx| {
+                if can_check {
+                    log::error!("UNIMPLEMENTED: check and fetch updates");
+                }
+            });
+
+        Box::new(state_change)
+    }
+
+    /// Do nothing, without errors.
+    fn nop(&mut self) -> ResponseActFuture<Self, (), ()> {
+        let nop = actix::fut::ok(());
+        Box::new(nop)
+    }
+}

--- a/src/update_agent/mod.rs
+++ b/src/update_agent/mod.rs
@@ -1,0 +1,109 @@
+//! Update agent.
+
+mod actor;
+
+use crate::config::Settings;
+use crate::identity::Identity;
+use crate::strategy::UpdateStrategy;
+use chrono::prelude::*;
+use std::time::Duration;
+
+/// Default tick/refresh period for the state machine (in seconds).
+const DEFAULT_REFRESH_PERIOD_SECS: u64 = 5 * 60;
+
+/// State machine for the agent.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum UpdateAgentState {
+    /// Initial state upon actor start.
+    StartState,
+    /// Agent initialized.
+    Initialized,
+    /// Agent ready to check for updates.
+    Steady,
+    // TODO(lucab): add all the "update in progress" states.
+    /// Final state upon actor end.
+    _EndState,
+}
+
+impl Default for UpdateAgentState {
+    fn default() -> Self {
+        UpdateAgentState::StartState
+    }
+}
+
+impl UpdateAgentState {
+    /// Transition to the Initialized state.
+    fn initialized(&mut self) {
+        // Allowed starting states.
+        assert!(*self == UpdateAgentState::StartState);
+
+        *self = UpdateAgentState::Initialized;
+    }
+
+    /// Transition to the Steady state.
+    fn steady(&mut self, is_steady: bool) {
+        // Allowed starting states.
+        assert!(*self == UpdateAgentState::Initialized);
+
+        if is_steady {
+            *self = UpdateAgentState::Steady;
+        }
+    }
+}
+
+/// Update agent.
+#[derive(Debug)]
+pub(crate) struct UpdateAgent {
+    /// Agent identity.
+    identity: Identity,
+    /// State machine tick/refresh period.
+    refresh_period: Duration,
+    /// Update strategy.
+    strategy: UpdateStrategy,
+    /// Current status for agent state machine.
+    state: UpdateAgentState,
+    /// Timestamp of last state transition.
+    state_changed: DateTime<Utc>,
+}
+
+impl UpdateAgent {
+    /// Build an update agent with the given config.
+    pub(crate) fn with_config(cfg: Settings) -> failure::Fallible<Self> {
+        let agent = UpdateAgent {
+            identity: cfg.identity,
+            // TODO(lucab): consider tweaking this
+            //   * maybe configurable, in minutes?
+            //   * maybe more granular, per-state?
+            refresh_period: Duration::from_secs(DEFAULT_REFRESH_PERIOD_SECS),
+            state: UpdateAgentState::default(),
+            strategy: cfg.strategy,
+            state_changed: chrono::Utc::now(),
+        };
+        Ok(agent)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_state() {
+        assert_eq!(UpdateAgentState::default(), UpdateAgentState::StartState);
+    }
+
+    #[test]
+    fn state_machine_happy_path() {
+        let mut machine = UpdateAgentState::default();
+        assert_eq!(machine, UpdateAgentState::StartState);
+
+        machine.initialized();
+        assert_eq!(machine, UpdateAgentState::Initialized);
+
+        machine.steady(true);
+        assert_eq!(machine, UpdateAgentState::Steady);
+
+        // TODO(lucab): complete the full path till reaching EndState.
+        // assert_eq!(machine, UpdateAgentState::_EndState);
+    }
+}


### PR DESCRIPTION
This adds the main state-machine for the update agent.
The agent is modeled as an actix actor which periodically
tries to refresh its state-machine. It progresses through
individual states in order to check, fetch and finalize updates.