### PR TITLE
config: update example with cincinnati URL

### DIFF
--- a/dist/examples/00-config-sample.toml
+++ b/dist/examples/00-config-sample.toml
@@ -9,7 +9,8 @@ group = "workers"
 #throttle_permille = "990"
 
 # Base URL to the Cincinnati service
-#cincinnati.base_url= "http://localhost:6789"
+[cincinnati]
+base_url= "http://example.com:80/"
 
 [updates]
 # Valid strategies: immediate / periodic / remote_http

--- a/src/config/fragments.rs
+++ b/src/config/fragments.rs
@@ -79,7 +79,9 @@ mod tests {
         let cfg: ConfigFragment = toml::from_slice(&content).unwrap();
 
         let expected = ConfigFragment {
-            cincinnati: None,
+            cincinnati: Some(CincinnatiFragment {
+                base_url: Some("http://example.com:80/".to_string()),
+            }),
             identity: Some(IdentityFragment {
                 group: Some("workers".to_string()),
                 node_uuid: None,


### PR DESCRIPTION
This updates the TOML sample config, which now includes
a URL entry for Cincinnati.