### PR TITLE
cincinnati: support fetching update-hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +213,16 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cgmath"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +252,15 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "colored"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -364,6 +388,11 @@ dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "digest"
@@ -838,6 +867,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +928,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "num-integer"
 version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1066,6 +1118,30 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1253,6 +1329,11 @@ dependencies = [
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-demangle"
@@ -1958,6 +2039,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "winconsole"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rgb 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winreg"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2086,7 @@ dependencies = [
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsystemd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mockito 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2011,6 +2104,7 @@ dependencies = [
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
@@ -2028,9 +2122,11 @@ dependencies = [
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a0c56216487bb80eec9c4516337b2588a4f2a2290d72a1416d930e4dcdb0c90d"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
+"checksum cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cdb90b60f2927f8d76139c72dbde7e10c3a2bc47c8594c9c7a66529f2687c03"
 "checksum cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "99be24cfcf40d56ed37fd11c2123be833959bbc5bddecb46e1c2e442e15fa3e0"
 "checksum cookie_store 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b0d2f2ecb21dce00e2453268370312978af9b8024020c7a37ae2cc6dbbe64685"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
@@ -2044,6 +2140,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fbe9f11be34f800b3ecaaed0ec9ec2e015d1d0ba0c8644c1310f73d6e8994615"
+"checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
@@ -2099,11 +2196,13 @@ dependencies = [
 "checksum mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum mockito 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d303c060b18db22e0a9ac12133c32f927c3f980b6f70004bc0cb2f8accc94704"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
@@ -2125,6 +2224,8 @@ dependencies = [
 "checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
+"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+"checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
@@ -2143,6 +2244,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddcfd2c13c6af0f9c45a1086be3b9c68af79e4430b42790759e2d34cce2a6c60"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
+"checksum rgb 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)" = "4f089652ca87f5a82a62935ec6172a534066c7b97be003cc8f702ee9a7a59c92"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
@@ -2224,6 +2326,7 @@ dependencies = [
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
+"checksum winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef84b96d10db72dd980056666d7f1e7663ce93d82fa33b63e71c966f4cf5032"
 "checksum winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
 "checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ toml = "^0.5.0"
 url_serde = "^0.2.0"
 
 [dev-dependencies]
+mockito = "^0.17"
 proptest = "^0.9"
 tokio = "^0.1"
 

--- a/src/cincinnati/client.rs
+++ b/src/cincinnati/client.rs
@@ -1,0 +1,132 @@
+//! Asynchronous Cincinnati client.
+//!
+//! This client implements the [Cincinnati protocol] for update-hints.
+//!
+//! [Cincinnati protocol]: https://github.com/openshift/cincinnati/blob/master/docs/design/cincinnati.md#graph-api
+
+// TODO(lucab): eventually move to its own "cincinnati client library" crate
+
+#![allow(unused)]
+
+use failure::{Error, Fallible, ResultExt};
+use futures::future;
+use futures::prelude::*;
+use reqwest::r#async as asynchro;
+use reqwest::Method;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// Cincinnati graph API path endpoint (v1).
+static V1_GRAPH_PATH: &str = "v1/graph";
+
+/// Cincinnati JSON protocol: node object.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct Node {
+    pub version: String,
+    pub payload: String,
+    pub metadata: HashMap<String, String>,
+}
+
+/// Cincinnati JSON protocol: graph object.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub struct Graph {
+    pub nodes: Vec<Node>,
+    pub edges: Vec<(u64, u64)>,
+}
+
+/// Client to make outgoing API requests.
+#[derive(Clone, Debug)]
+pub struct Client {
+    /// Base URL for API endpoint.
+    api_base: reqwest::Url,
+    /// Asynchronous reqwest client.
+    hclient: asynchro::Client,
+    /// Client parameters (query portion).
+    query_params: HashMap<String, String>,
+}
+
+impl Client {
+    /// Fetch an update-graph from Cincinnati.
+    pub fn fetch_graph(&self) -> impl Future<Item = Graph, Error = Error> {
+        let req = self.new_request(Method::GET, V1_GRAPH_PATH);
+        future::result(req)
+            .and_then(|req| req.send().from_err())
+            .and_then(|resp| resp.error_for_status().map_err(Error::from))
+            .and_then(|mut resp| resp.json::<Graph>().from_err())
+    }
+
+    /// Return a request builder with base URL and parameters set.
+    fn new_request<S: AsRef<str>>(
+        &self,
+        method: reqwest::Method,
+        url_suffix: S,
+    ) -> Fallible<asynchro::RequestBuilder> {
+        let url = self.api_base.clone().join(url_suffix.as_ref())?;
+        let builder = self
+            .hclient
+            .request(method, url)
+            .header("content-type", "application/json")
+            .query(&self.query_params);
+        Ok(builder)
+    }
+}
+
+/// Client builder.
+#[derive(Clone, Debug)]
+pub struct ClientBuilder {
+    /// Base URL for API endpoint (mandatory).
+    api_base: String,
+    /// Asynchronous reqwest client (custom).
+    hclient: Option<asynchro::Client>,
+    /// Client parameters (custom).
+    query_params: Option<HashMap<String, String>>,
+}
+
+impl ClientBuilder {
+    /// Return a new builder for the given base API endpoint URL.
+    pub fn new<T>(api_base: T) -> Self
+    where
+        T: Into<String>,
+    {
+        Self {
+            api_base: api_base.into(),
+            hclient: None,
+            query_params: None,
+        }
+    }
+
+    /// Set (or reset) the query parameters to use.
+    pub fn query_params(self, params: Option<HashMap<String, String>>) -> Self {
+        let mut builder = self;
+        builder.query_params = params;
+        builder
+    }
+
+    /// Set (or reset) the HTTP client to use.
+    pub fn http_client(self, hclient: Option<asynchro::Client>) -> Self {
+        let mut builder = self;
+        builder.hclient = hclient;
+        builder
+    }
+
+    /// Build a client with specified parameters.
+    pub fn build(self) -> Fallible<Client> {
+        let hclient = match self.hclient {
+            Some(client) => client,
+            None => asynchro::ClientBuilder::new().build()?,
+        };
+        let query_params = match self.query_params {
+            Some(params) => params,
+            None => HashMap::new(),
+        };
+
+        let api_base = reqwest::Url::parse(&self.api_base)
+            .context(format!("failed to parse '{}'", &self.api_base))?;
+        let client = Client {
+            api_base,
+            hclient,
+            query_params,
+        };
+        Ok(client)
+    }
+}

--- a/src/cincinnati/mock_tests.rs
+++ b/src/cincinnati/mock_tests.rs
@@ -1,0 +1,26 @@
+use crate::cincinnati::*;
+use crate::identity::Identity;
+use mockito::{self, Matcher};
+use tokio::runtime::current_thread as rt;
+
+#[test]
+fn test_empty_graph() {
+    let empty_graph = r#"{ "nodes": [], "edges": [] }"#;
+    let m_graph = mockito::mock("GET", Matcher::Regex(r"^/v1/graph?.+$".to_string()))
+        .match_header(
+            "content-type",
+            Matcher::Regex("application/json".to_string()),
+        )
+        .with_body(&empty_graph)
+        .with_status(200)
+        .create();
+
+    let id = Identity::mock_default(None);
+    let client = Cincinnati {
+        base_url: mockito::server_url(),
+    };
+    let update = rt::block_on_all(client.next_update(&id));
+    m_graph.assert();
+
+    assert!(update.unwrap().is_none());
+}

--- a/src/cincinnati/mod.rs
+++ b/src/cincinnati/mod.rs
@@ -1,0 +1,103 @@
+//! Asynchronous Cincinnati client.
+
+// Cincinnati client.
+mod client;
+pub use client::Node;
+
+#[cfg(test)]
+mod mock_tests;
+
+use crate::config::inputs;
+use crate::identity::Identity;
+use failure::{bail, format_err, Error, Fallible};
+use futures::future;
+use futures::prelude::*;
+use serde::Serialize;
+
+/// Cincinnati configuration.
+#[derive(Debug, Serialize)]
+pub struct Cincinnati {
+    /// Service base URL.
+    pub base_url: String,
+}
+
+impl Cincinnati {
+    /// Process Cincinnati configuration.
+    pub(crate) fn with_config(cfg: inputs::CincinnatiInput, id: &Identity) -> Fallible<Self> {
+        if cfg.base_url.is_empty() {
+            bail!("empty Cincinnati base URL");
+        }
+
+        // TODO(lucab): add envsubst
+        let _env = id.url_variables();
+        let c = Self {
+            base_url: cfg.base_url,
+        };
+        Ok(c)
+    }
+
+    /// Fetch next update-hint from Cincinnati.
+    pub(crate) fn fetch_update_hint(
+        &self,
+        id: &Identity,
+        can_check: bool,
+    ) -> Box<Future<Item = Option<Node>, Error = ()>> {
+        if !can_check {
+            return Box::new(futures::future::ok(None));
+        }
+
+        let update = self
+            .next_update(id)
+            .map_err(|e| log::error!("failed to check for updates: {}", e));
+        Box::new(update)
+    }
+
+    /// Get the next update.
+    fn next_update(&self, id: &Identity) -> Box<Future<Item = Option<Node>, Error = Error>> {
+        let params = id.cincinnati_params();
+        let cur_version = id.current_version.clone();
+        let client = client::ClientBuilder::new(self.base_url.to_string())
+            .query_params(Some(params))
+            .build();
+
+        let next = future::result(client)
+            .and_then(|c| c.fetch_graph())
+            .and_then(|graph| find_update(graph, cur_version))
+            .map_err(|e| format_err!("failed to query Cincinnati: {}", e));
+        Box::new(next)
+    }
+}
+
+/// Walk the graph, looking for an update reachable from current version.
+fn find_update(graph: client::Graph, cur_version: String) -> Fallible<Option<Node>> {
+    let cur_position = match graph.nodes.iter().position(|n| n.version == cur_version) {
+        Some(pos) => pos,
+        None => return Ok(None),
+    };
+
+    let targets: Vec<_> = graph
+        .edges
+        .iter()
+        .filter_map(|(src, dst)| {
+            if *src == cur_position as u64 {
+                Some(*dst as usize)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let mut updates = Vec::with_capacity(targets.len());
+    for pos in targets {
+        match graph.nodes.get(pos) {
+            Some(n) => updates.push(n.clone()),
+            None => bail!("target node '{}' not present in graph"),
+        };
+    }
+
+    match updates.len() {
+        0 => Ok(None),
+        // TODO(lucab): stable pick next update
+        _ => Ok(Some(updates.swap_remove(0))),
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,6 +11,7 @@ mod fragments;
 /// Configuration fragments.
 pub(crate) mod inputs;
 
+use crate::cincinnati::Cincinnati;
 use crate::identity::Identity;
 use crate::strategy::UpdateStrategy;
 use failure::{Fallible, ResultExt};
@@ -22,6 +23,8 @@ use structopt::clap::crate_name;
 /// It holds validated agent configuration.
 #[derive(Debug, Serialize)]
 pub(crate) struct Settings {
+    /// Cincinnati configuration.
+    pub(crate) cincinnati: Cincinnati,
     /// Agent configuration.
     pub(crate) identity: Identity,
     /// Agent update strategy.
@@ -41,8 +44,14 @@ impl Settings {
         let identity = Identity::with_config(cfg.identity)
             .context("failed to validate agent identity configuration")?;
         let strategy = UpdateStrategy::with_config(cfg.updates)
-            .context("failed to validate agent updates configuration")?;
+            .context("failed to validate update-strategy configuration")?;
+        let cincinnati = Cincinnati::with_config(cfg.cincinnati, &identity)
+            .context("failed to validate cincinnati configuration")?;
 
-        Ok(Self { identity, strategy })
+        Ok(Self {
+            cincinnati,
+            identity,
+            strategy,
+        })
     }
 }

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -32,6 +32,7 @@ pub(crate) struct Identity {
 }
 
 impl Identity {
+    /// Create from configuration.
     pub(crate) fn with_config(cfg: inputs::IdentityInput) -> Fallible<Self> {
         let mut id = Self::try_default().context("failed to build default identity")?;
 

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -102,6 +102,19 @@ impl Identity {
         }
         vars
     }
+
+    #[cfg(test)]
+    pub(crate) fn mock_default(throttle_permille: Option<u16>) -> Self {
+        Self {
+            basearch: "mock-amd64".to_string(),
+            current_version: "0.0.0-mock".to_string(),
+            group: "mock-workers".to_string(),
+            node_uuid: id128::Id128::parse_str("e0f3745b108f471cbd4883c6fbed8cdd").unwrap(),
+            platform: "mock-azure".to_string(),
+            stream: "mock-stable".to_string(),
+            throttle_permille,
+        }
+    }
 }
 
 fn read_stream() -> Fallible<String> {
@@ -138,21 +151,9 @@ fn compute_node_uuid(app_id: &id128::Id128) -> Fallible<id128::Id128> {
 mod tests {
     use super::*;
 
-    fn mock_default(throttle_permille: Option<u16>) -> Identity {
-        Identity {
-            basearch: "mock-amd64".to_string(),
-            current_version: "0.0.0-mock".to_string(),
-            group: "mock-workers".to_string(),
-            node_uuid: id128::Id128::parse_str("e0f3745b108f471cbd4883c6fbed8cdd").unwrap(),
-            platform: "mock-azure".to_string(),
-            stream: "mock-stable".to_string(),
-            throttle_permille,
-        }
-    }
-
     #[test]
     fn identity_url_variables() {
-        let id = mock_default(Some(500));
+        let id = Identity::mock_default(Some(500));
         let vars = id.url_variables();
 
         assert!(vars.contains_key("basearch"));
@@ -166,7 +167,7 @@ mod tests {
 
     #[test]
     fn identity_cincinnati_params() {
-        let id = mock_default(Some(500));
+        let id = Identity::mock_default(Some(500));
         let vars = id.cincinnati_params();
 
         assert!(vars.contains_key("basearch"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 
+// Cincinnati client.
+mod cincinnati;
 /// Command-line options.
 mod cli;
 /// File-based configuration.


### PR DESCRIPTION
This adds a Cincinnati client, which is used by the agent in order
to fetch update hints and progress its state machine.