### PR TITLE
cincinnati: fix media-type header

### DIFF
--- a/src/cincinnati/client.rs
+++ b/src/cincinnati/client.rs
@@ -65,7 +65,7 @@ impl Client {
         let builder = self
             .hclient
             .request(method, url)
-            .header("content-type", "application/json")
+            .header("accept", "application/json")
             .query(&self.query_params);
         Ok(builder)
     }

--- a/src/cincinnati/mock_tests.rs
+++ b/src/cincinnati/mock_tests.rs
@@ -8,7 +8,7 @@ fn test_empty_graph() {
     let empty_graph = r#"{ "nodes": [], "edges": [] }"#;
     let m_graph = mockito::mock("GET", Matcher::Regex(r"^/v1/graph?.+$".to_string()))
         .match_header(
-            "content-type",
+            "accept",
             Matcher::Regex("application/json".to_string()),
         )
         .with_body(&empty_graph)


### PR DESCRIPTION
This fixes the media-type header on client request, according to
https://github.com/openshift/cincinnati/blob/master/docs/design/cincinnati.md#request