### PR TITLE
rpm_ostree: add basic client-actor for upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2090,6 +2090,7 @@ dependencies = [
  "proptest 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ libsystemd = "^0.1.0"
 log = "^0.4.6"
 reqwest = "^0.9.15"
 serde = { version = "^1.0.90", features = ["derive"] }
+serde_json = "^1.0.39"
 structopt = "^0.2.15"
 toml = "^0.5.0"
 url_serde = "^0.2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ mod cli;
 mod config;
 /// Agent identity.
 mod identity;
+/// rpm-ostree client.
+mod rpm_ostree;
 /// Update strategies.
 mod strategy;
 /// Update agent.
@@ -62,8 +64,11 @@ fn run_agent() -> failure::Fallible<()> {
         .stop_on_panic(true)
         .build();
 
+    trace!("creating rpm-ostree client");
+    let rpm_ostree_addr = rpm_ostree::RpmOstreeClient::start(1);
+
     trace!("creating update agent");
-    let agent = update_agent::UpdateAgent::with_config(settings)
+    let agent = update_agent::UpdateAgent::with_config(settings, rpm_ostree_addr)
         .context("failed to assemble update-agent from configuration settings")?;
     let _addr = agent.start();
 

--- a/src/rpm_ostree/actor.rs
+++ b/src/rpm_ostree/actor.rs
@@ -1,0 +1,41 @@
+//! rpm-ostree client actor.
+
+use super::Release;
+use actix::prelude::*;
+use failure::Fallible;
+use log::trace;
+
+/// Client actor for rpm-ostree.
+#[derive(Debug, Default, Clone)]
+pub struct RpmOstreeClient {}
+
+impl Actor for RpmOstreeClient {
+    type Context = SyncContext<Self>;
+}
+
+impl RpmOstreeClient {
+    /// Start the threadpool for rpm-ostree blocking clients.
+    pub fn start(threads: usize) -> Addr<Self> {
+        SyncArbiter::start(threads, RpmOstreeClient::default)
+    }
+}
+
+/// Request: stage a deployment (in finalization-locked mode).
+#[derive(Debug, Clone)]
+pub struct StageDeployment {
+    /// Release to be staged.
+    pub release: Release,
+}
+
+impl Message for StageDeployment {
+    type Result = Fallible<Release>;
+}
+
+impl Handler<StageDeployment> for RpmOstreeClient {
+    type Result = Fallible<Release>;
+
+    fn handle(&mut self, msg: StageDeployment, _ctx: &mut Self::Context) -> Self::Result {
+        trace!("request to stage release: {:?}", msg.release);
+        super::cli_upgrade::locked_upgrade(msg.release)
+    }
+}

--- a/src/rpm_ostree/cli_status.rs
+++ b/src/rpm_ostree/cli_status.rs
@@ -1,0 +1,68 @@
+//! Interface to `rpm-ostree status --json`.
+
+#![allow(unused)]
+
+use super::Release;
+use failure::{bail, ensure, format_err, Fallible, ResultExt};
+use serde::Deserialize;
+
+/// JSON output from `rpm-ostree status --json`
+#[derive(Debug, Deserialize)]
+pub struct StatusJSON {
+    deployments: Vec<DeploymentJSON>,
+}
+
+/// Partial deployment object (only fields relevant to zincati).
+#[derive(Debug, Deserialize)]
+pub struct DeploymentJSON {
+    booted: bool,
+    #[serde(rename = "base-checksum")]
+    base_checksum: Option<String>,
+    checksum: String,
+    version: String,
+}
+
+impl DeploymentJSON {
+    /// Convert into `Release`.
+    pub fn into_release(self) -> Release {
+        Release {
+            checksum: self.base_revision(),
+            version: self.version,
+        }
+    }
+
+    /// Return the deployment base revision.
+    pub fn base_revision(&self) -> String {
+        self.base_checksum
+            .clone()
+            .unwrap_or_else(|| self.checksum.clone())
+    }
+}
+
+/// Find the booted deployment.
+pub fn booted() -> Fallible<Release> {
+    let cmd = std::process::Command::new("rpm-ostree")
+        .arg("status")
+        .arg("--json")
+        .arg("--booted")
+        .output()
+        .with_context(|e| format_err!("failed to run rpm-ostree: {}", e))?;
+
+    if !cmd.status.success() {
+        bail!(
+            "rpm-ostree status failed:\n{}",
+            String::from_utf8_lossy(&cmd.stderr)
+        );
+    }
+    let status: StatusJSON = serde_json::from_slice(&cmd.stdout)?;
+
+    let booted = status
+        .deployments
+        .into_iter()
+        .find(|d| d.booted)
+        .ok_or_else(|| format_err!("no booted deployment found"))?;
+
+    ensure!(!booted.base_revision().is_empty(), "empty base revision");
+    ensure!(!booted.version.is_empty(), "empty version");
+    Ok(booted.into_release())
+}

--- a/src/rpm_ostree/cli_upgrade.rs
+++ b/src/rpm_ostree/cli_upgrade.rs
@@ -1,0 +1,23 @@
+//! Interface to `rpm-ostree upgrade --lock-finalization`.
+
+use super::Release;
+use failure::{bail, format_err, Fallible, ResultExt};
+
+/// Upgrade and leave the new deployment locked.
+pub fn locked_upgrade(release: Release) -> Fallible<Release> {
+    let cmd = std::process::Command::new("rpm-ostree")
+        .arg("deploy")
+        .arg("--lock-finalization")
+        .arg(release.reference_id())
+        .output()
+        .with_context(|e| format_err!("failed to run rpm-ostree: {}", e))?;
+
+    if !cmd.status.success() {
+        bail!(
+            "rpm-ostree upgrade failed:\n{}",
+            String::from_utf8_lossy(&cmd.stderr)
+        );
+    }
+
+    Ok(release)
+}

--- a/src/rpm_ostree/mod.rs
+++ b/src/rpm_ostree/mod.rs
@@ -1,0 +1,31 @@
+mod cli_status;
+mod cli_upgrade;
+
+mod actor;
+pub use actor::{RpmOstreeClient, StageDeployment};
+
+use crate::cincinnati::Node;
+
+/// An OS release.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Release {
+    /// OS version.
+    pub version: String,
+    /// Image checksum
+    pub checksum: String,
+}
+
+impl Release {
+    /// Builds a `Release` object from a Cincinnati node.
+    pub fn from_cincinnati(node: Node) -> Self {
+        Self {
+            version: node.version,
+            checksum: node.payload,
+        }
+    }
+
+    /// Returns the reference ID for this release.
+    pub fn reference_id(&self) -> String {
+        format!("revision={}", self.checksum)
+    }
+}


### PR DESCRIPTION
This adds an initial actor for rpm-ostree CLI client.
It also sketches the first step in downloading and applying updates.