### PR TITLE
cincinnati: support templated values in base URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "envsubst"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "error-chain"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2089,7 @@ dependencies = [
  "actix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "envsubst 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2147,6 +2156,7 @@ dependencies = [
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum enum-as-inner 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3d58266c97445680766be408285e798d3401c6d4c378ec5552e78737e681e37d"
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
+"checksum envsubst 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96bb109e9bbf902e948594cc5143cc21a97016bb56252db357657da5407cdf10"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 actix = "^0.8.1"
 env_logger = "^0.6.1"
+envsubst = "^0.1.0"
 failure = "^0.1.5"
 futures = "^0.1.26"
 chrono = "^0.4.6"

--- a/src/cincinnati/mod.rs
+++ b/src/cincinnati/mod.rs
@@ -28,11 +28,16 @@ impl Cincinnati {
             bail!("empty Cincinnati base URL");
         }
 
-        // TODO(lucab): add envsubst
-        let _env = id.url_variables();
-        let c = Self {
-            base_url: cfg.base_url,
+        /// Substitute templated key with agent runtime values.
+        let base_url = if envsubst::is_templated(&cfg.base_url) {
+            let context = id.url_variables();
+            envsubst::validate_vars(&context)?;
+            envsubst::substitute(cfg.base_url, &context)?
+        } else {
+            cfg.base_url
         };
+
+        let c = Self { base_url };
         Ok(c)
     }
 


### PR DESCRIPTION
This adds support for simple templated variables substitution on
Cincinnati base URL.