### PR TITLE
cincinnati: lookup by OS checksum

### DIFF
--- a/src/rpm_ostree/mod.rs
+++ b/src/rpm_ostree/mod.rs
@@ -1,18 +1,20 @@
 mod cli_deploy;
 mod cli_finalize;
 mod cli_status;
+pub use cli_status::booted;
 
 mod actor;
 pub use actor::{FinalizeDeployment, RpmOstreeClient, StageDeployment};
 
 use crate::cincinnati::Node;
+use serde::Serialize;
 
 /// An OS release.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct Release {
     /// OS version.
     pub version: String,
-    /// Image checksum
+    /// Image base checksum.
     pub checksum: String,
 }
 


### PR DESCRIPTION
This switches the graph-lookup logic handling lookup in Cincinnati,
in order to use OS (base) checksum instead of version labels.

Closes: https://github.com/coreos/zincati/issues/25