### PR TITLE
strategy/immediate: remove config options

### DIFF
--- a/src/config/fragments.rs
+++ b/src/config/fragments.rs
@@ -35,21 +35,9 @@ pub(crate) struct CincinnatiFragment {
 pub(crate) struct UpdateFragment {
     /// Update strategy (default: immediate)
     pub(crate) strategy: Option<String>,
-    /// `immediate` strategy config.
-    pub(crate) immediate: Option<UpImmediateFragment>,
-    /// `periodic` strategy config.
     pub(crate) periodic: Option<UpPeriodicFragment>,
     /// `remote_http` strategy config.
     pub(crate) remote_http: Option<UpHttpFragment>,
-}
-
-/// Config fragment for `immediate` update strategy.
-#[derive(Debug, Deserialize, PartialEq, Eq)]
-pub(crate) struct UpImmediateFragment {
-    /// Whether to check for and fetch updates.
-    pub(crate) fetch_updates: Option<String>,
-    /// Whether to finalize staged updates.
-    pub(crate) finalize_updates: Option<String>,
 }
 
 /// Config fragment for `remote_http` update strategy.
@@ -89,10 +77,6 @@ mod tests {
             }),
             updates: Some(UpdateFragment {
                 strategy: Some("immediate".to_string()),
-                immediate: Some(UpImmediateFragment {
-                    fetch_updates: Some("true".to_string()),
-                    finalize_updates: Some("true".to_string()),
-                }),
                 periodic: None,
                 remote_http: None,
             }),

--- a/src/config/inputs.rs
+++ b/src/config/inputs.rs
@@ -127,8 +127,6 @@ impl IdentityInput {
 #[derive(Debug, Serialize)]
 pub(crate) struct UpdateInput {
     pub(crate) strategy: String,
-    /// `immediate` strategy config.
-    pub(crate) immediate: StratImmediateInput,
     /// `remote_http` strategy config.
     pub(crate) remote_http: StratHttpInput,
     /// `periodic` strategy config.
@@ -138,10 +136,6 @@ pub(crate) struct UpdateInput {
 impl UpdateInput {
     fn from_fragments(fragments: Vec<fragments::UpdateFragment>) -> Self {
         let mut strategy = String::new();
-        let mut immediate = StratImmediateInput {
-            fetch_updates: None,
-            finalize_updates: None,
-        };
         let mut remote_http = StratHttpInput {
             base_url: String::new(),
         };
@@ -156,19 +150,10 @@ impl UpdateInput {
                     remote_http.base_url = b;
                 }
             }
-            if let Some(i) = snip.immediate {
-                if let Some(check) = i.fetch_updates {
-                    immediate.fetch_updates = Some(check.parse().unwrap());
-                }
-                if let Some(finalize) = i.finalize_updates {
-                    immediate.finalize_updates = Some(finalize.parse().unwrap());
-                }
-            }
         }
 
         Self {
             strategy,
-            immediate,
             remote_http,
             periodic,
         }
@@ -185,10 +170,3 @@ pub(crate) struct StratHttpInput {
 /// Config snippet for `periodic` strategy.
 #[derive(Debug, Serialize)]
 pub(crate) struct StratPeriodicInput {}
-
-/// Config snippet for `immediate` strategy.
-#[derive(Debug, Serialize)]
-pub(crate) struct StratImmediateInput {
-    pub(crate) fetch_updates: Option<bool>,
-    pub(crate) finalize_updates: Option<bool>,
-}

--- a/src/strategy/immediate.rs
+++ b/src/strategy/immediate.rs
@@ -1,8 +1,5 @@
 //! Strategy for immediate updates.
 
-#![allow(unused)]
-
-use crate::config::inputs::StratImmediateInput;
 use failure::{Error, Fallible};
 use futures::future;
 use futures::prelude::*;
@@ -19,20 +16,6 @@ pub(crate) struct StrategyImmediate {
 }
 
 impl StrategyImmediate {
-    /// Try to parse strategy configuration.
-    pub(crate) fn with_config(cfg: StratImmediateInput) -> Fallible<Self> {
-        let mut immediate = Self::default();
-
-        if let Some(check) = cfg.fetch_updates {
-            immediate.check = check;
-        }
-        if let Some(finalize) = cfg.finalize_updates {
-            immediate.finalize = finalize;
-        }
-
-        Ok(immediate)
-    }
-
     /// Check if finalization is allowed.
     pub(crate) fn can_finalize(&self) -> impl Future<Item = bool, Error = Error> {
         trace!(
@@ -91,36 +74,33 @@ mod tests {
     proptest! {
         #[test]
         fn proptest_config(check in any::<bool>(), finalize in any::<bool>()){
-            let input = StratImmediateInput {
-                fetch_updates: Some(check),
-                finalize_updates: Some(finalize),
+            let strat = StrategyImmediate{
+                check,
+                finalize
             };
 
-            let strat = StrategyImmediate::with_config(input).unwrap();
             assert_eq!(strat.check, check);
             assert_eq!(strat.finalize, finalize);
         }
 
         #[test]
         fn proptest_can_check(check in any::<bool>(), finalize in any::<bool>()){
-            let input = StratImmediateInput {
-                fetch_updates: Some(check),
-                finalize_updates: Some(finalize),
+            let strat = StrategyImmediate{
+                check,
+                finalize
             };
 
-            let strat = StrategyImmediate::with_config(input).unwrap();
             let can_check = rt::block_on_all(strat.can_check_and_fetch()).unwrap();
             assert_eq!(can_check, check);
         }
 
         #[test]
         fn proptest_can_finalize(check in any::<bool>(), finalize in any::<bool>()){
-            let input = StratImmediateInput {
-                fetch_updates: Some(check),
-                finalize_updates: Some(finalize),
+            let strat = StrategyImmediate{
+                check,
+                finalize
             };
 
-            let strat = StrategyImmediate::with_config(input).unwrap();
             let can_finalize = rt::block_on_all(strat.can_finalize()).unwrap();
             assert_eq!(can_finalize, finalize);
         }

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -21,7 +21,7 @@ impl UpdateStrategy {
     /// Try to parse config inputs into a valid strategy.
     pub(crate) fn with_config(cfg: inputs::UpdateInput) -> Fallible<Self> {
         let strategy = match cfg.strategy.as_ref() {
-            "immediate" => UpdateStrategy::try_immediate(cfg.immediate)?,
+            "immediate" => UpdateStrategy::new_immediate()?,
             "" => UpdateStrategy::default(),
             x => bail!("unsupported strategy '{}'", x),
         };
@@ -64,8 +64,8 @@ impl UpdateStrategy {
         Box::new(can_check)
     }
 
-    fn try_immediate(cfg: inputs::StratImmediateInput) -> Fallible<Self> {
-        let immediate = StrategyImmediate::with_config(cfg)?;
+    fn new_immediate() -> Fallible<Self> {
+        let immediate = StrategyImmediate::default();
         Ok(UpdateStrategy::Immediate(immediate))
     }
 }

--- a/tests/fixtures/00-config-sample.toml
+++ b/tests/fixtures/00-config-sample.toml
@@ -12,13 +12,7 @@ group = "workers"
 [cincinnati]
 base_url= "http://example.com:80/"
 
-[updates]
 # Valid strategies: immediate / periodic / remote_http
-strategy = "immediate"
-
+[updates]
 # Immediately check for, fetch and finalize updates
-[updates.immediate]
-# Whether to check for and fetch updates
-fetch_updates = "true"
-# Whether to finalize staged updates
-finalize_updates = "true"
+strategy = "immediate"


### PR DESCRIPTION
This removes existing config options for `strategy.immediate`. It
was deemed that these options don't have a strong-enough usecase
at this point, and it is easy to add them later if proper
requirements arise.