### PR TITLE
cargo: add metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "zincati"
 version = "0.0.0-dev.0"
+description = "Update agent for Fedora CoreOS"
+license = "Apache-2.0"
+keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]
 authors = ["Luca Bruno <luca.bruno@coreos.com>"]
+repository = "https://github.com/coreos/zincati"
 edition = "2018"
 
 [dependencies]
@@ -29,3 +33,12 @@ tokio = "^0.1"
 
 [profile.release]
 lto = true
+
+[package.metadata.release]
+sign-commit = true
+upload-doc = false
+disable-publish = true
+disable-push = true
+pre-release-commit-message = "cargo: zincati release {{version}}"
+pro-release-commit-message = "cargo: development version bump"
+tag-message = "zincati {{version}}"


### PR DESCRIPTION
This adds Cargo manifest metadata, in preparation for the first release.