### PR TITLE
config: update fedora-coreos backend URL

### DIFF
--- a/dist/config.d/50-fedora-coreos-cincinnati.toml
+++ b/dist/config.d/50-fedora-coreos-cincinnati.toml
@@ -1,3 +1,3 @@
 # Fedora CoreOS Cincinnati backend (staging service)
 [cincinnati]
-base_url= "https://updates.stg.coreos.fedoraproject.org"
+base_url= "https://updates.coreos.stg.fedoraproject.org"


### PR DESCRIPTION
There was a last-minute change in the planned backend URL, due
to how fedora-infra production and staging DNS environments
are organized. This updates Zincati config to reflect such change.