### PR TITLE
config: use liboverdrop scanner 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,14 @@ version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "liboverdrop"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libsystemd"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,6 +2375,7 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "liboverdrop 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsystemd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2484,6 +2493,7 @@ dependencies = [
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
+"checksum liboverdrop 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dd07dbfac49716996379d2b118934808bbd033208edb3fb7ff3acf4e66ad8e7e"
 "checksum libsystemd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b613f5b2b8b90db24f7b81310b9c9b8f5cff11929bd95044f8a1084cf9442f0a"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ futures = "^0.1.26"
 chrono = "^0.4.6"
 glob = "^0.3.0"
 lazy_static = "^1.3.0"
+liboverdrop = "^0.0.1"
 libsystemd = "^0.1.0"
 log = "^0.4.6"
 prometheus = { version = "^0.6.1", default-features = false }

--- a/dist/tmpfiles.d/zincati.conf
+++ b/dist/tmpfiles.d/zincati.conf
@@ -1,6 +1,9 @@
 #Type Path                   Mode User    Group    Age Argument
 d     /run/zincati           0775 zincati zincati  -   -
 
+# Runtime configuration fragments
+d     /run/zincati/config.d  0775 zincati zincati  -   -
+
 # Runtime state, unstable/private implementation details
 d     /run/zincati/private   0770 zincati zincati  -   -
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -34,8 +34,14 @@ pub(crate) struct Settings {
 impl Settings {
     /// Assemble runtime settings.
     pub(crate) fn assemble() -> Fallible<Self> {
-        let dirs = vec!["/usr/lib", "/run", "/etc"];
-        let cfg = inputs::ConfigInput::read_configs(&dirs, crate_name!())?;
+        let prefixes = vec![
+            "/usr/lib/".to_string(),
+            "/run/".to_string(),
+            "/etc/".to_string(),
+        ];
+        let common_path = format!("{}/config.d/", crate_name!());
+        let extensions = vec!["toml".to_string()];
+        let cfg = inputs::ConfigInput::read_configs(prefixes, &common_path, extensions)?;
         Self::validate(cfg)
     }
 


### PR DESCRIPTION
This updates configuration logic, dropping our custom file scanner and using [liboverdrop](https://docs.rs/liboverdrop/0.0.1/liboverdrop/struct.FragmentScanner.html#method.scan) instead.