### PR TITLE
Release 0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.2-alpha.0"
+version = "0.0.2"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.2"
+version = "0.0.3-alpha.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.2"
+version = "0.0.3-alpha.0"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.2-alpha.0"
+version = "0.0.2"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]


### PR DESCRIPTION
 * config: use liboverdrop scanner 
 * config: update fedora-coreos backend URL
 * zincati: add metrics collection and reporting
