### PR TITLE
identity: update hardcoded stream

### DIFF
--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -127,7 +127,7 @@ impl Identity {
 
 fn read_stream() -> Fallible<String> {
     // TODO(lucab): read this from os-release.
-    let ver = "stable".to_string();
+    let ver = "testing".to_string();
     Ok(ver)
 }
 


### PR DESCRIPTION
This updates the hardcoded stream label, as a temporary measure for
preview release.

Ref: https://github.com/coreos/zincati/issues/55