### PR TITLE
dist: add polkit rule for rpm-ostree

### DIFF
--- a/dist/polkit-1/rules.d/zincati.rules
+++ b/dist/polkit-1/rules.d/zincati.rules
@@ -1,0 +1,8 @@
+// Allow Zincati to deploy, and finalize a staged deployment through rpm-ostree.
+polkit.addRule(function(action, subject) {
+    if ((action.id == "org.projectatomic.rpmostree1.deploy" ||
+         action.id == "org.projectatomic.rpmostree1.finalize-deployment") &&
+        subject.user == "zincati") {
+        return polkit.Result.YES;
+    }
+})


### PR DESCRIPTION
Add a polkit rule to allow the `zincati` user to make `deploy` and
`finalize-deployment` calls to the D-Bus API exposed by rpm-ostree.