### PR TITLE
update_agent: add a knob to disable auto-updates logic

### DIFF
--- a/dist/config.d/10-auto-updates.toml
+++ b/dist/config.d/10-auto-updates.toml
@@ -1,0 +1,3 @@
+# Enable auto-updates.
+[updates]
+enabled = true

--- a/docs/usage/auto-updates.md
+++ b/docs/usage/auto-updates.md
@@ -1,0 +1,21 @@
+# Auto-updates
+
+Available updates are discovered by periodically polling a [Cincinnati] server.
+Once available, they are automatically applied via [rpm-ostree] and a machine reboot.
+
+[Cincinnati]: https://github.com/openshift/cincinnati
+[rpm-ostree]: https://github.com/projectatomic/rpm-ostree
+
+## Disabling auto-update
+
+To disable auto-updates, a configuration snippet containing the following has to be installed on the system:
+
+```
+[updates]
+enabled = false
+```
+
+Make sure that it has higher priority than previous settings, by using a path like `/etc/zincati/config.d/90-disable-auto-updates.toml`.
+
+When auto-updates are disabled, Zincati does not perform any update action.
+However, the service does not terminate and is kept alive idle for external status observers. 

--- a/src/config/fragments.rs
+++ b/src/config/fragments.rs
@@ -33,8 +33,11 @@ pub(crate) struct CincinnatiFragment {
 /// Config fragment for update logic.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 pub(crate) struct UpdateFragment {
-    /// Update strategy (default: immediate)
+    /// Whether to enable auto-updates logic.
+    pub(crate) enabled: Option<bool>,
+    /// Update strategy (default: immediate).
     pub(crate) strategy: Option<String>,
+    /// `periodic` strategy config.
     pub(crate) periodic: Option<UpPeriodicFragment>,
     /// `remote_http` strategy config.
     pub(crate) remote_http: Option<UpHttpFragment>,
@@ -76,6 +79,7 @@ mod tests {
                 throttle_permille: None,
             }),
             updates: Some(UpdateFragment {
+                enabled: Some(false),
                 strategy: Some("immediate".to_string()),
                 periodic: None,
                 remote_http: None,

--- a/src/config/inputs.rs
+++ b/src/config/inputs.rs
@@ -125,6 +125,9 @@ impl IdentityInput {
 /// Config for update logic.
 #[derive(Debug, Serialize)]
 pub(crate) struct UpdateInput {
+    /// Whether to enable auto-updates logic.
+    pub(crate) enabled: bool,
+    /// Update strategy.
     pub(crate) strategy: String,
     /// `remote_http` strategy config.
     pub(crate) remote_http: StratHttpInput,
@@ -134,6 +137,7 @@ pub(crate) struct UpdateInput {
 
 impl UpdateInput {
     fn from_fragments(fragments: Vec<fragments::UpdateFragment>) -> Self {
+        let mut enabled = true;
         let mut strategy = String::new();
         let mut remote_http = StratHttpInput {
             base_url: String::new(),
@@ -141,6 +145,9 @@ impl UpdateInput {
         let periodic = StratPeriodicInput {};
 
         for snip in fragments {
+            if let Some(e) = snip.enabled {
+                enabled = e;
+            }
             if let Some(s) = snip.strategy {
                 strategy = s;
             }
@@ -152,6 +159,7 @@ impl UpdateInput {
         }
 
         Self {
+            enabled,
             strategy,
             remote_http,
             periodic,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,6 +23,8 @@ use structopt::clap::crate_name;
 /// It holds validated agent configuration.
 #[derive(Debug, Serialize)]
 pub(crate) struct Settings {
+    /// Whether to enable auto-updates logic.
+    pub(crate) enabled: bool,
     /// Cincinnati configuration.
     pub(crate) cincinnati: Cincinnati,
     /// Agent configuration.
@@ -47,6 +49,7 @@ impl Settings {
 
     /// Validate config and return a valid agent settings.
     fn validate(cfg: inputs::ConfigInput) -> Fallible<Self> {
+        let enabled = cfg.updates.enabled;
         let identity = Identity::with_config(cfg.identity)
             .context("failed to validate agent identity configuration")?;
         let strategy = UpdateStrategy::with_config(cfg.updates)
@@ -55,6 +58,7 @@ impl Settings {
             .context("failed to validate cincinnati configuration")?;
 
         Ok(Self {
+            enabled,
             cincinnati,
             identity,
             strategy,

--- a/src/update_agent/actor.rs
+++ b/src/update_agent/actor.rs
@@ -94,7 +94,12 @@ impl UpdateAgent {
         trace!("update agent in start state");
 
         let initialization = self.nop().map(|_r, actor, _ctx| {
-            actor.state.initialized();
+            if actor.enabled {
+                actor.state.initialized();
+            } else {
+                log::info!("auto-updates logic disabled by configuration");
+                actor.state.end();
+            }
         });
 
         Box::new(initialization)

--- a/tests/fixtures/00-config-sample.toml
+++ b/tests/fixtures/00-config-sample.toml
@@ -14,5 +14,7 @@ base_url= "http://example.com:80/"
 
 # Valid strategies: immediate / periodic / remote_http
 [updates]
+# Disable auto-updates.
+enabled = false
 # Immediately check for, fetch and finalize updates
 strategy = "immediate"


### PR DESCRIPTION
This adds an `updates.enabled = <bool>` configuration entry to disable
auto-updates logic.

Closes: https://github.com/coreos/zincati/issues/62