### PR TITLE
rpm-ostree: improve input validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,6 +996,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,6 +2384,7 @@ dependencies = [
  "liboverdrop 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsystemd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2501,6 +2507,7 @@ dependencies = [
 "checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+"checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static = "^1.3.0"
 liboverdrop = "^0.0.2"
 libsystemd = "^0.1.0"
 log = "^0.4.6"
+maplit = "^1.0"
 prometheus = { version = "^0.7.0", default-features = false }
 reqwest = "^0.9.13"
 serde = { version = "^1.0.94", features = ["derive"] }

--- a/src/rpm_ostree/mod.rs
+++ b/src/rpm_ostree/mod.rs
@@ -22,6 +22,8 @@ pub struct Release {
 impl Release {
     /// Builds a `Release` object from a Cincinnati node.
     pub fn from_cincinnati(node: Node) -> Fallible<Self> {
+        ensure!(!node.version.is_empty(), "empty version field");
+        ensure!(!node.payload.is_empty(), "empty payload field (checksum)");
         let scheme = node
             .metadata
             .get(SCHEME_KEY)
@@ -38,5 +40,51 @@ impl Release {
             checksum: node.payload,
         };
         Ok(rel)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use maplit::hashmap;
+
+    #[test]
+    fn release_from_cincinnati() {
+        let input = Node {
+            version: "mock-version".to_string(),
+            payload: "mock-payload".to_string(),
+            metadata: hashmap! {
+                SCHEME_KEY.to_string() => CHECKSUM_SCHEME.to_string(),
+            },
+        };
+        Release::from_cincinnati(input).unwrap();
+    }
+
+    #[test]
+    fn invalid_node() {
+        let node1 = Node {
+            version: "".to_string(),
+            payload: "mock-payload".to_string(),
+            metadata: hashmap! {
+                SCHEME_KEY.to_string() => CHECKSUM_SCHEME.to_string(),
+            },
+        };
+        Release::from_cincinnati(node1).unwrap_err();
+
+        let node2 = Node {
+            version: "mock-version".to_string(),
+            payload: "".to_string(),
+            metadata: hashmap! {
+                SCHEME_KEY.to_string() => CHECKSUM_SCHEME.to_string(),
+            },
+        };
+        Release::from_cincinnati(node2).unwrap_err();
+
+        let node3 = Node {
+            version: "mock-version".to_string(),
+            payload: "mock-payload".to_string(),
+            metadata: hashmap! {},
+        };
+        Release::from_cincinnati(node3).unwrap_err();
     }
 }


### PR DESCRIPTION
This improves input validation on input releases/nodes coming
from the Cincinnati server, with relevant tests too.