### PR TITLE
identity: introspect updates stream

### DIFF
--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -57,7 +57,8 @@ impl Identity {
 
     /// Try to build default agent identity.
     pub fn try_default() -> Fallible<Self> {
-        let basearch = rpm_ostree::basearch()?;
+        let basearch =
+            rpm_ostree::basearch().context("failed to introspect OS base architecture")?;
         let current_os = rpm_ostree::booted().context("failed to introspect booted OS image")?;
         let node_uuid = {
             let app_id = id128::Id128::try_from_slice(APP_ID)
@@ -65,8 +66,8 @@ impl Identity {
             compute_node_uuid(&app_id)?
         };
         let platform = platform::read_id("/proc/cmdline")?;
-        // TODO(lucab): populate this from node introspection.
-        let stream = read_stream()?;
+        let stream =
+            rpm_ostree::updates_stream().context("failed to introspect OS updates stream")?;
 
         let id = Self {
             basearch,
@@ -122,12 +123,6 @@ impl Identity {
             throttle_permille,
         }
     }
-}
-
-fn read_stream() -> Fallible<String> {
-    // TODO(lucab): read this from os-release.
-    let ver = "testing".to_string();
-    Ok(ver)
 }
 
 fn compute_node_uuid(app_id: &id128::Id128) -> Fallible<id128::Id128> {

--- a/src/rpm_ostree/cli_status.rs
+++ b/src/rpm_ostree/cli_status.rs
@@ -29,6 +29,8 @@ pub struct DeploymentJSON {
 struct BaseCommitMetaJSON {
     #[serde(rename = "coreos-assembler.basearch")]
     basearch: String,
+    #[serde(rename = "fedora-coreos.stream")]
+    stream: String,
 }
 
 impl DeploymentJSON {
@@ -60,6 +62,14 @@ pub fn booted() -> Fallible<Release> {
     let status = status_json(true)?;
     let json = booted_json(status)?;
     Ok(json.into_release())
+}
+
+/// Return updates stream for booted deployment.
+pub fn updates_stream() -> Fallible<String> {
+    let status = status_json(true)?;
+    let json = booted_json(status)?;
+    ensure!(!json.base_metadata.stream.is_empty(), "empty stream value");
+    Ok(json.base_metadata.stream)
 }
 
 /// Return JSON object for booted deployment.
@@ -117,5 +127,12 @@ mod tests {
         let status = mock_status().unwrap();
         let booted = booted_json(status).unwrap();
         assert_eq!(booted.base_metadata.basearch, "x86_64");
+    }
+
+    #[test]
+    fn mock_booted_updates_stream() {
+        let status = mock_status().unwrap();
+        let booted = booted_json(status).unwrap();
+        assert_eq!(booted.base_metadata.stream, "testing-devel");
     }
 }

--- a/src/rpm_ostree/mod.rs
+++ b/src/rpm_ostree/mod.rs
@@ -1,7 +1,7 @@
 mod cli_deploy;
 mod cli_finalize;
 mod cli_status;
-pub use cli_status::{basearch, booted};
+pub use cli_status::{basearch, booted, updates_stream};
 
 mod actor;
 pub use actor::{FinalizeDeployment, RpmOstreeClient, StageDeployment};

--- a/tests/fixtures/rpm-ostree-status.json
+++ b/tests/fixtures/rpm-ostree-status.json
@@ -8,6 +8,7 @@
         "coreos-assembler.config-dirty" : "true",
         "coreos-assembler.config-gitrev" : "e5ffda727170e124c7f7d8782e256b0462bf9869",
         "coreos-assembler.basearch" : "x86_64",
+        "fedora-coreos.stream" : "testing-devel",
         "rpmostree.inputhash" : "0e2ba98bac847c8a8cc5ffd42822a41d53ef6719ccaf6a0094559768aa24da33",
         "version" : "30.1",
         "rpmostree.rpmmd-repos" : [


### PR DESCRIPTION
This removes the hardcoded stream value, introspecting it from booted
deployment metadata instead.

Closes: https://github.com/coreos/zincati/issues/55