### PR TITLE
Release 0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.3"
+version = "0.0.4-alpha.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.3-alpha.0"
+version = "0.0.3"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.3-alpha.0"
+version = "0.0.3"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.3"
+version = "0.0.4-alpha.0"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]


### PR DESCRIPTION
zincati 0.0.3:
* identity: introspect updates stream
* rpm_ostree/deploy: record metrics
* update_agent: add a knob to disable auto-updates logic
* rpm-ostree: improve input validation
* identity: introspect basearch
* dist: add polkit rule for rpm-ostree
* update-agent: observe state changes
* identity: update hardcoded stream
