### PR TITLE
dist/systemd: delay zincati boot order

### DIFF
--- a/dist/systemd/system/zincati.service
+++ b/dist/systemd/system/zincati.service
@@ -1,6 +1,11 @@
 [Unit]
 Description=Zincati Update Agent
 Documentation=https://github.com/coreos/zincati
+After=network.target
+# Wait for the boot to be marked as successful. In cluster contexts,
+# this prevents rolling out broken updates to all nodes in the fleet.
+Requires=boot-complete.target
+After=boot-complete.target
 
 [Service]
 User=zincati


### PR DESCRIPTION
This tweaks Zincati service unit in order to start a bit later in
the boot process.

In particular, we want to be scheduled after two other targets
have been reached:
 * `network.target`: network is required to reach Cincinnati, so it
   should start setting up before zincati starts.
 * `boot-complete.target`: for remote coordination, releasing the
   locked update-slot should happen only if the system is fully
   operational after reboot.