### PR TITLE
cincinnati: drop throttle parameter

### DIFF
--- a/src/cincinnati/mock_tests.rs
+++ b/src/cincinnati/mock_tests.rs
@@ -12,7 +12,7 @@ fn test_empty_graph() {
         .with_status(200)
         .create();
 
-    let id = Identity::mock_default(None);
+    let id = Identity::mock_default();
     let client = Cincinnati {
         base_url: mockito::server_url(),
     };

--- a/src/config/fragments.rs
+++ b/src/config/fragments.rs
@@ -19,8 +19,6 @@ pub(crate) struct IdentityFragment {
     pub(crate) group: Option<String>,
     /// Update group for this agent (default: derived from machine-id)
     pub(crate) node_uuid: Option<String>,
-    /// Throttle bucket for this agent (default: dynamically computed)
-    pub(crate) throttle_permille: Option<String>,
 }
 
 /// Config fragment for Cincinnati client.
@@ -76,7 +74,6 @@ mod tests {
             identity: Some(IdentityFragment {
                 group: Some("workers".to_string()),
                 node_uuid: None,
-                throttle_permille: None,
             }),
             updates: Some(UpdateFragment {
                 enabled: Some(false),

--- a/src/config/inputs.rs
+++ b/src/config/inputs.rs
@@ -95,7 +95,6 @@ impl CincinnatiInput {
 pub(crate) struct IdentityInput {
     pub(crate) group: String,
     pub(crate) node_uuid: String,
-    pub(crate) throttle_permille: Option<u16>,
 }
 
 impl IdentityInput {
@@ -103,7 +102,6 @@ impl IdentityInput {
         let mut cfg = Self {
             group: String::new(),
             node_uuid: String::new(),
-            throttle_permille: None,
         };
 
         for snip in fragments {
@@ -112,9 +110,6 @@ impl IdentityInput {
             }
             if let Some(nu) = snip.node_uuid {
                 cfg.node_uuid = nu;
-            }
-            if let Some(tp) = snip.throttle_permille {
-                cfg.throttle_permille = Some(tp.parse().unwrap());
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ mod update_agent;
 
 use actix::Actor;
 use failure::ResultExt;
-use log::{debug, info, trace};
+use log::{info, trace};
 use structopt::clap::{crate_name, crate_version};
 use structopt::StructOpt;
 

--- a/tests/fixtures/00-config-sample.toml
+++ b/tests/fixtures/00-config-sample.toml
@@ -5,9 +5,6 @@ group = "workers"
 # Node UUID: by default derived from "/etc/machine-id"
 #node_uuid = "27e3ac02-af39-46af-995c-9940e18b0cce"
 
-# Update throttling (min: 1, max: 1000): by default computed by the Cincinnati service
-#throttle_permille = "990"
-
 # Base URL to the Cincinnati service
 [cincinnati]
 base_url= "http://example.com:80/"


### PR DESCRIPTION
This drops the `throttle_permille` parameter, as it is not going
to be stabilized in its current form as part of the protocol.