### PR TITLE
rpm_ostree/finalize: record metrics

### DIFF
--- a/src/rpm_ostree/cli_finalize.rs
+++ b/src/rpm_ostree/cli_finalize.rs
@@ -2,9 +2,22 @@
 
 use super::Release;
 use failure::{bail, format_err, Fallible, ResultExt};
+use prometheus::IntCounter;
+
+lazy_static::lazy_static! {
+    static ref FINALIZE_ATTEMPTS: IntCounter = register_int_counter!(opts!(
+        "zincati_rpm_ostree_finalize_attempts_total",
+        "Total number of 'rpm-ostree finalize-deployment' attempts."
+    )).unwrap();
+    static ref FINALIZE_FAILURES: IntCounter = register_int_counter!(opts!(
+        "zincati_rpm_ostree_finalize_failures_total",
+        "Total number of 'rpm-ostree finalize-deployment' failures."
+    )).unwrap();
+}
 
 /// Unlock and finalize the new deployment.
 pub fn finalize_deployment(release: Release) -> Fallible<Release> {
+    FINALIZE_ATTEMPTS.inc();
     let cmd = std::process::Command::new("rpm-ostree")
         .arg("finalize-deployment")
         .arg(&release.checksum)
@@ -12,6 +25,7 @@ pub fn finalize_deployment(release: Release) -> Fallible<Release> {
         .with_context(|e| format_err!("failed to run rpm-ostree: {}", e))?;
 
     if !cmd.status.success() {
+        FINALIZE_FAILURES.inc();
         bail!(
             "rpm-ostree finalize-deployment failed:\n{}",
             String::from_utf8_lossy(&cmd.stderr)


### PR DESCRIPTION
This records some metrics on 'rpm-ostree finalize-deployment' runs,
including total attempts and failures.