### PR TITLE
rpm_ostree/deploy: add faulting tests for CLI calls 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ matrix:
 
 script:
   - cargo test
+  - cargo test --features failpoints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fail"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,6 +2379,7 @@ dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "envsubst 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fail 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2457,6 +2468,7 @@ dependencies = [
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum envsubst 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13cf19a8d534c83456ea13365a1935810a39f0e43bf1ec9371077e1966da396a"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
+"checksum fail 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f63eec71a3013ee912a0ecb339ff0c5fa5ed9660df04bfefa10c250b885d018c"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ actix = "^0.8.1"
 cfg-if = "^0.1.9"
 env_logger = "^0.6.2"
 envsubst = "^0.1.0"
+fail = "^0.3.0"
 failure = "^0.1.5"
 futures = "^0.1.28"
 chrono = "^0.4.7"
@@ -35,6 +36,9 @@ url_serde = "^0.2.0"
 mockito = "^0.17"
 proptest = "^0.9"
 tokio = "^0.1"
+
+[features]
+failpoints = [ "fail/failpoints" ]
 
 [profile.release]
 lto = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 
+#[macro_use(fail_point)]
+extern crate fail;
 #[macro_use]
 extern crate prometheus;
 

--- a/src/rpm_ostree/cli_deploy.rs
+++ b/src/rpm_ostree/cli_deploy.rs
@@ -18,6 +18,20 @@ lazy_static::lazy_static! {
 /// Deploy an upgrade (by checksum) and leave the new deployment locked.
 pub fn deploy_locked(release: Release) -> Fallible<Release> {
     DEPLOY_ATTEMPTS.inc();
+
+    let result = invoke_cli(release);
+    if result.is_err() {
+        DEPLOY_FAILURES.inc();
+    }
+
+    result
+}
+
+/// CLI executor.
+fn invoke_cli(release: Release) -> Fallible<Release> {
+    fail_point!("deploy_locked_err", |_| bail!("deploy_locked_err"));
+    fail_point!("deploy_locked_ok", |_| Ok(release.clone()));
+
     let cmd = std::process::Command::new("rpm-ostree")
         .arg("deploy")
         .arg("--lock-finalization")
@@ -26,12 +40,47 @@ pub fn deploy_locked(release: Release) -> Fallible<Release> {
         .with_context(|e| format_err!("failed to run rpm-ostree: {}", e))?;
 
     if !cmd.status.success() {
-        DEPLOY_FAILURES.inc();
         bail!(
             "rpm-ostree deploy failed:\n{}",
             String::from_utf8_lossy(&cmd.stderr)
         );
     }
-
     Ok(release)
+}
+
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+
+    #[cfg(feature = "failpoints")]
+    #[test]
+    fn deploy_locked_err() {
+        let _guard = fail::FailScenario::setup();
+        fail::cfg("deploy_locked_err", "return").unwrap();
+
+        let release = Release {
+            version: "foo".to_string(),
+            checksum: "bar".to_string(),
+        };
+        let result = deploy_locked(release);
+        assert!(result.is_err());
+        assert!(DEPLOY_ATTEMPTS.get() >= 1);
+        assert!(DEPLOY_FAILURES.get() >= 1);
+    }
+
+    #[cfg(feature = "failpoints")]
+    #[test]
+    fn deploy_locked_ok() {
+        let _guard = fail::FailScenario::setup();
+        fail::cfg("deploy_locked_ok", "return").unwrap();
+
+        let release = Release {
+            version: "foo".to_string(),
+            checksum: "bar".to_string(),
+        };
+        let result = deploy_locked(release.clone()).unwrap();
+        assert_eq!(result, release);
+        assert!(DEPLOY_ATTEMPTS.get() >= 1);
+    }
 }


### PR DESCRIPTION
This adds some testing mocks around `rpm-ostree deploy`, starting
with simple metrics checks. Failpoints in here can be later re-used
in order to test consumers.