### PR TITLE
Release 0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.4"
+version = "0.0.5-alpha.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.4-alpha.0"
+version = "0.0.4"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.4-alpha.0"
+version = "0.0.4"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.4"
+version = "0.0.5-alpha.0"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]


### PR DESCRIPTION
 * rpm_ostree/deploy: add faulting tests for CLI calls 
 * update_agent: log relevant transaction events
 * rpm_ostree/finalize: record metrics
 * cincinnati: drop throttle parameter
 * zincati: tweak logging
 * dist/systemd: delay zincati boot order
 * docs: show how to tweak verbosity
 * docs: show metrics usage
 * cincinnati/metrics: instrument update checks
 * cargo: update dependencies