### PR TITLE
identity: allow setting rollout wariness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "owning_ref"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,6 +2460,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2601,6 +2611,7 @@ dependencies = [
 "checksum openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)" = "97c140cbb82f3b3468193dd14c1b88def39f341f68257f8a7fe8ed9ed3f628a5"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)" = "75bdd6dbbb4958d38e47a1d2348847ad1eb4dc205dc5d37473ae504391865acc"
+"checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ liboverdrop = "^0.0.2"
 libsystemd = "^0.1.0"
 log = "^0.4.8"
 maplit = "^1.0"
+ordered-float = { version = "^1.0.2", features = ["serde"] }
 prometheus = { version = "^0.7.0", default-features = false }
 reqwest = "^0.9.19"
 serde = { version = "^1.0.98", features = ["derive"] }

--- a/dist/config.d/10-auto-updates.toml
+++ b/dist/config.d/10-auto-updates.toml
@@ -1,3 +1,6 @@
 # Enable auto-updates.
 [updates]
+
+# Boolean to enable auto-update logic.
+# There is almost no case where disabling this is a good idea.
 enabled = true

--- a/dist/config.d/10-identity.toml
+++ b/dist/config.d/10-identity.toml
@@ -1,0 +1,15 @@
+# Configure agent identity.
+[identity]
+
+# Node group, used for cluster-wide reboot orchestration (e.g. Airlock).
+group = "default"
+
+# Node ID, in sd-id128(3) format.
+# By default it is automatically computed as
+# `systemd-id128 machine-id -a de35106b6ec24688b63afddaa156679b`
+#node_uuid = "<ID128>"
+
+# Client wariness for throttled rollouts, as a floating point number.
+# Allowed values are within the range from `0.0` (very bold clients) to `1.0` (cautious clients), limits included.
+# By default, clients are arbitrarily throttled by the Cincinnati server.
+#rollout_wariness = 0.5

--- a/src/config/fragments.rs
+++ b/src/config/fragments.rs
@@ -1,5 +1,6 @@
 //! TOML configuration fragments.
 
+use ordered_float::NotNan;
 use serde::Deserialize;
 
 /// Top-level configuration stanza.
@@ -19,6 +20,8 @@ pub(crate) struct IdentityFragment {
     pub(crate) group: Option<String>,
     /// Update group for this agent (default: derived from machine-id)
     pub(crate) node_uuid: Option<String>,
+    /// Update group for this agent (default: derived server-side)
+    pub(crate) rollout_wariness: Option<NotNan<f64>>,
 }
 
 /// Config fragment for Cincinnati client.
@@ -73,7 +76,8 @@ mod tests {
             }),
             identity: Some(IdentityFragment {
                 group: Some("workers".to_string()),
-                node_uuid: None,
+                node_uuid: Some("27e3ac02af3946af995c9940e18b0cce".to_string()),
+                rollout_wariness: Some(NotNan::new(0.5).unwrap()),
             }),
             updates: Some(UpdateFragment {
                 enabled: Some(false),

--- a/src/config/inputs.rs
+++ b/src/config/inputs.rs
@@ -1,6 +1,7 @@
 use crate::config::fragments;
 use failure::{Fallible, ResultExt};
 use log::trace;
+use ordered_float::NotNan;
 use serde::Serialize;
 
 /// Runtime configuration holding environmental inputs.
@@ -95,6 +96,7 @@ impl CincinnatiInput {
 pub(crate) struct IdentityInput {
     pub(crate) group: String,
     pub(crate) node_uuid: String,
+    pub(crate) rollout_wariness: Option<NotNan<f64>>,
 }
 
 impl IdentityInput {
@@ -102,6 +104,7 @@ impl IdentityInput {
         let mut cfg = Self {
             group: String::new(),
             node_uuid: String::new(),
+            rollout_wariness: None,
         };
 
         for snip in fragments {
@@ -110,6 +113,9 @@ impl IdentityInput {
             }
             if let Some(nu) = snip.node_uuid {
                 cfg.node_uuid = nu;
+            }
+            if let Some(rw) = snip.rollout_wariness {
+                cfg.rollout_wariness = Some(rw);
             }
         }
 

--- a/tests/fixtures/00-config-sample.toml
+++ b/tests/fixtures/00-config-sample.toml
@@ -1,17 +1,11 @@
 [identity]
-# Node group: used for cluster-wide reboot orchestration (via remote strategy)
 group = "workers"
+node_uuid = "27e3ac02af3946af995c9940e18b0cce"
+rollout_wariness = 0.5
 
-# Node UUID: by default derived from "/etc/machine-id"
-#node_uuid = "27e3ac02-af39-46af-995c-9940e18b0cce"
-
-# Base URL to the Cincinnati service
 [cincinnati]
 base_url= "http://example.com:80/"
 
-# Valid strategies: immediate / periodic / remote_http
 [updates]
-# Disable auto-updates.
 enabled = false
-# Immediately check for, fetch and finalize updates
 strategy = "immediate"


### PR DESCRIPTION
This exposes an `identity.rollout_wariness = <float>` configuration
knob. It allows clients to pick their own constant wariness for
throttled rollout. Allowed values are within the range from `0.0`
(bold clients) to `1.0` (cautious clients), limits included.

Closes: https://github.com/coreos/zincati/issues/82