### PR TITLE
rpm_ostree: add release ordering based on age-index

### DIFF
--- a/src/cincinnati/mod.rs
+++ b/src/cincinnati/mod.rs
@@ -16,6 +16,9 @@ use prometheus::{IntCounter, IntGauge};
 use serde::Serialize;
 
 /// Metadata key for payload scheme.
+pub static AGE_INDEX_KEY: &str = "org.fedoraproject.coreos.releases.age_index";
+
+/// Metadata key for payload scheme.
 pub static SCHEME_KEY: &str = "org.fedoraproject.coreos.scheme";
 
 /// Metadata value for "checksum" payload scheme.

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -118,6 +118,7 @@ impl Identity {
             current_os: rpm_ostree::Release {
                 version: "0.0.0-mock".to_string(),
                 checksum: "sha-mock".to_string(),
+                age_index: None,
             },
             group: "mock-workers".to_string(),
             node_uuid: id128::Id128::parse_str("e0f3745b108f471cbd4883c6fbed8cdd").unwrap(),

--- a/src/rpm_ostree/cli_deploy.rs
+++ b/src/rpm_ostree/cli_deploy.rs
@@ -62,6 +62,7 @@ mod tests {
         let release = Release {
             version: "foo".to_string(),
             checksum: "bar".to_string(),
+            age_index: None,
         };
         let result = deploy_locked(release);
         assert!(result.is_err());
@@ -78,6 +79,7 @@ mod tests {
         let release = Release {
             version: "foo".to_string(),
             checksum: "bar".to_string(),
+            age_index: None,
         };
         let result = deploy_locked(release.clone()).unwrap();
         assert_eq!(result, release);

--- a/src/rpm_ostree/cli_status.rs
+++ b/src/rpm_ostree/cli_status.rs
@@ -39,6 +39,7 @@ impl DeploymentJSON {
         Release {
             checksum: self.base_revision(),
             version: self.version,
+            age_index: None,
         }
     }
 

--- a/src/rpm_ostree/mock_tests.rs
+++ b/src/rpm_ostree/mock_tests.rs
@@ -1,0 +1,55 @@
+use crate::cincinnati::Cincinnati;
+use crate::rpm_ostree::Release;
+use crate::identity::Identity;
+use mockito::{self, Matcher};
+use tokio::runtime::current_thread as rt;
+
+#[test]
+fn test_simple_graph() {
+    let simple_graph = r#"
+{
+  "nodes": [
+    {
+      "version": "0.0.0-mock",
+      "metadata": {
+        "org.fedoraproject.coreos.scheme": "checksum",
+        "org.fedoraproject.coreos.releases.age_index": "0"
+      },
+      "payload": "sha-mock"
+    },
+    {
+      "version": "30.20190725.0",
+      "metadata": {
+        "org.fedoraproject.coreos.scheme": "checksum",
+        "org.fedoraproject.coreos.releases.age_index": "1"
+      },
+      "payload": "8b79877efa7ac06becd8637d95f8ca83aa385f89f383288bf3c2c31ca53216c7"
+    }
+  ],
+  "edges": [
+    [
+      0,
+      1
+    ]
+  ]
+}
+"#;
+
+    let m_graph = mockito::mock("GET", Matcher::Regex(r"^/v1/graph?.+$".to_string()))
+        .match_header("accept", Matcher::Regex("application/json".to_string()))
+        .with_body(&simple_graph)
+        .with_status(200)
+        .create();
+
+    let id = Identity::mock_default();
+    let client = Cincinnati {
+        base_url: mockito::server_url(),
+    };
+    let update = rt::block_on_all(client.fetch_update_hint(&id, true)).unwrap();
+    m_graph.assert();
+
+    let node = update.unwrap();
+    let next = Release::from_cincinnati(node).unwrap();
+
+    assert_eq!(next.version, "30.20190725.0")
+}

--- a/src/update_agent/mod.rs
+++ b/src/update_agent/mod.rs
@@ -193,6 +193,7 @@ mod tests {
         let update = Release {
             version: "v1".to_string(),
             checksum: "ostree-checksum".to_string(),
+            age_index: None,
         };
         machine.update_available(Some(update.clone()));
         assert_eq!(machine, UpdateAgentState::UpdateAvailable(update.clone()));


### PR DESCRIPTION
This implements total ordering on releases, based on metadata
provided by the Cincinnati server.
In particular, from now on we require a metadata entry named
`org.fedoraproject.coreos.releases.age_index` which allows us
to compare the age (i.e. positional index) of releases as they
originally appear in the stream release index.