### PR TITLE
updates: block downgrades, expose opt-in config

### DIFF
--- a/dist/config.d/10-auto-updates.toml
+++ b/dist/config.d/10-auto-updates.toml
@@ -4,3 +4,8 @@
 # Boolean to enable auto-update logic.
 # There is almost no case where disabling this is a good idea.
 enabled = true
+
+# Boolean to allow downgrading via updates logic.
+# This provides an additional safety net against rogue servers,
+# and allowing downgrades via Zincati is generally not recommended.
+allow_downgrade = false

--- a/docs/usage/auto-updates.md
+++ b/docs/usage/auto-updates.md
@@ -55,6 +55,24 @@ For further documentation on configurations, check the [updates strategy][update
 [strategy-fleet_lock]: updates-strategy.md#lock-based-strategy
 [updates-strategy]: updates-strategy.md
 
+## Updates ordering and downgrades
+
+OS updates have a strict ascending ordering called "age index", which is based on the date and time of release.
+Versions that have been released earlier in time have a lower index than recent ones.
+
+Zincati uses this absolute ordering to prefer newer releases (i.e. with higher age index) when multiple updates are available at the same time.
+By default, this ordering is also used to prevent automatic downgrades.
+
+For custom environments where automatic downgrades have to be supported, the following configuration snippet can be used to enable them:
+
+```toml
+[updates]
+allow_downgrade = true
+```
+
+Enabling such logic removes an additional safety check, and may allow rogue Cincinnati servers to induce downgrades to old releases with known security vulnerabilities.
+It is generally not recommended to allow and perform automatic downgrades via Zincati.
+
 ## Disabling auto-updates
 
 To disable auto-updates, a configuration snippet containing the following has to be installed on the system:

--- a/src/cincinnati/mock_tests.rs
+++ b/src/cincinnati/mock_tests.rs
@@ -17,7 +17,7 @@ fn test_empty_graph() {
     let client = Cincinnati {
         base_url: mockito::server_url(),
     };
-    let update = rt::block_on_all(client.next_update(&id, BTreeSet::new()));
+    let update = rt::block_on_all(client.next_update(&id, BTreeSet::new(), false));
     m_graph.assert();
 
     assert!(update.unwrap().is_none());

--- a/src/config/fragments.rs
+++ b/src/config/fragments.rs
@@ -34,6 +34,8 @@ pub(crate) struct CincinnatiFragment {
 /// Config fragment for update logic.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 pub(crate) struct UpdateFragment {
+    /// Whether to enable automatic downgrades.
+    pub(crate) allow_downgrade: Option<bool>,
     /// Whether to enable auto-updates logic.
     pub(crate) enabled: Option<bool>,
     /// Update strategy (default: immediate).
@@ -72,6 +74,7 @@ mod tests {
                 rollout_wariness: Some(NotNan::new(0.5).unwrap()),
             }),
             updates: Some(UpdateFragment {
+                allow_downgrade: Some(true),
                 enabled: Some(false),
                 strategy: Some("fleet_lock".to_string()),
                 fleet_lock: Some(UpdateFleetLock {

--- a/src/config/inputs.rs
+++ b/src/config/inputs.rs
@@ -126,6 +126,8 @@ impl IdentityInput {
 /// Config for update logic.
 #[derive(Debug, Serialize)]
 pub(crate) struct UpdateInput {
+    /// Whether to enable automatic downgrades.
+    pub(crate) allow_downgrade: bool,
     /// Whether to enable auto-updates logic.
     pub(crate) enabled: bool,
     /// Update strategy.
@@ -143,6 +145,7 @@ pub(crate) struct FleetLockInput {
 
 impl UpdateInput {
     fn from_fragments(fragments: Vec<fragments::UpdateFragment>) -> Self {
+        let mut allow_downgrade = false;
         let mut enabled = true;
         let mut strategy = String::new();
         let mut fleet_lock = FleetLockInput {
@@ -150,6 +153,9 @@ impl UpdateInput {
         };
 
         for snip in fragments {
+            if let Some(a) = snip.allow_downgrade {
+                allow_downgrade = a;
+            }
             if let Some(e) = snip.enabled {
                 enabled = e;
             }
@@ -164,6 +170,7 @@ impl UpdateInput {
         }
 
         Self {
+            allow_downgrade,
             enabled,
             strategy,
             fleet_lock,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,6 +23,8 @@ use structopt::clap::crate_name;
 /// It holds validated agent configuration.
 #[derive(Debug, Serialize)]
 pub(crate) struct Settings {
+    /// Whether to enable automatic downgrades.
+    pub(crate) allow_downgrade: bool,
     /// Whether to enable auto-updates logic.
     pub(crate) enabled: bool,
     /// Cincinnati configuration.
@@ -49,6 +51,7 @@ impl Settings {
 
     /// Validate config and return a valid agent settings.
     fn validate(cfg: inputs::ConfigInput) -> Fallible<Self> {
+        let allow_downgrade = cfg.updates.allow_downgrade;
         let enabled = cfg.updates.enabled;
         let identity = Identity::with_config(cfg.identity)
             .context("failed to validate agent identity configuration")?;
@@ -58,6 +61,7 @@ impl Settings {
             .context("failed to validate cincinnati configuration")?;
 
         Ok(Self {
+            allow_downgrade,
             enabled,
             cincinnati,
             identity,

--- a/src/rpm_ostree/actor.rs
+++ b/src/rpm_ostree/actor.rs
@@ -24,6 +24,8 @@ impl RpmOstreeClient {
 /// Request: stage a deployment (in finalization-locked mode).
 #[derive(Debug, Clone)]
 pub struct StageDeployment {
+    /// Whether to allow downgrades.
+    pub allow_downgrade: bool,
     /// Release to be staged.
     pub release: Release,
 }
@@ -37,7 +39,7 @@ impl Handler<StageDeployment> for RpmOstreeClient {
 
     fn handle(&mut self, msg: StageDeployment, _ctx: &mut Self::Context) -> Self::Result {
         trace!("request to stage release: {:?}", msg.release);
-        super::cli_deploy::deploy_locked(msg.release)
+        super::cli_deploy::deploy_locked(msg.release, msg.allow_downgrade)
     }
 }
 

--- a/src/rpm_ostree/cli_deploy.rs
+++ b/src/rpm_ostree/cli_deploy.rs
@@ -16,10 +16,10 @@ lazy_static::lazy_static! {
 }
 
 /// Deploy an upgrade (by checksum) and leave the new deployment locked.
-pub fn deploy_locked(release: Release) -> Fallible<Release> {
+pub fn deploy_locked(release: Release, allow_downgrade: bool) -> Fallible<Release> {
     DEPLOY_ATTEMPTS.inc();
 
-    let result = invoke_cli(release);
+    let result = invoke_cli(release, allow_downgrade);
     if result.is_err() {
         DEPLOY_FAILURES.inc();
     }
@@ -28,21 +28,26 @@ pub fn deploy_locked(release: Release) -> Fallible<Release> {
 }
 
 /// CLI executor.
-fn invoke_cli(release: Release) -> Fallible<Release> {
+fn invoke_cli(release: Release, allow_downgrade: bool) -> Fallible<Release> {
     fail_point!("deploy_locked_err", |_| bail!("deploy_locked_err"));
     fail_point!("deploy_locked_ok", |_| Ok(release.clone()));
 
-    let cmd = std::process::Command::new("rpm-ostree")
-        .arg("deploy")
+    let mut cmd = std::process::Command::new("rpm-ostree");
+    cmd.arg("deploy")
         .arg("--lock-finalization")
-        .arg(format!("revision={}", release.checksum))
+        .arg(format!("revision={}", release.checksum));
+    if !allow_downgrade {
+        cmd.arg("--disallow-downgrade");
+    }
+
+    let out = cmd
         .output()
         .with_context(|e| format_err!("failed to run rpm-ostree: {}", e))?;
 
-    if !cmd.status.success() {
+    if !out.status.success() {
         bail!(
             "rpm-ostree deploy failed:\n{}",
-            String::from_utf8_lossy(&cmd.stderr)
+            String::from_utf8_lossy(&out.stderr)
         );
     }
     Ok(release)
@@ -64,7 +69,7 @@ mod tests {
             checksum: "bar".to_string(),
             age_index: None,
         };
-        let result = deploy_locked(release);
+        let result = deploy_locked(release, true);
         assert!(result.is_err());
         assert!(DEPLOY_ATTEMPTS.get() >= 1);
         assert!(DEPLOY_FAILURES.get() >= 1);
@@ -81,7 +86,7 @@ mod tests {
             checksum: "bar".to_string(),
             age_index: None,
         };
-        let result = deploy_locked(release.clone()).unwrap();
+        let result = deploy_locked(release.clone(), true).unwrap();
         assert_eq!(result, release);
         assert!(DEPLOY_ATTEMPTS.get() >= 1);
     }

--- a/src/strategy/fleet_lock.rs
+++ b/src/strategy/fleet_lock.rs
@@ -103,6 +103,7 @@ mod tests {
     fn test_url_simple() {
         let id = Identity::mock_default();
         let input = UpdateInput {
+            allow_downgrade: false,
             enabled: true,
             strategy: "fleet_lock".to_string(),
             fleet_lock: FleetLockInput {
@@ -118,6 +119,7 @@ mod tests {
     fn test_empty_url() {
         let id = Identity::mock_default();
         let input = UpdateInput {
+            allow_downgrade: false,
             enabled: true,
             strategy: "fleet_lock".to_string(),
             fleet_lock: FleetLockInput {

--- a/src/update_agent/mod.rs
+++ b/src/update_agent/mod.rs
@@ -122,6 +122,8 @@ impl UpdateAgentState {
 /// Update agent.
 #[derive(Debug)]
 pub(crate) struct UpdateAgent {
+    /// Whether to allow automatic downgrades.
+    allow_downgrade: bool,
     /// Cincinnati service.
     cincinnati: Cincinnati,
     /// Whether to enable auto-updates logic.
@@ -147,6 +149,7 @@ impl UpdateAgent {
         rpm_ostree_addr: Addr<RpmOstreeClient>,
     ) -> failure::Fallible<Self> {
         let agent = UpdateAgent {
+            allow_downgrade: cfg.allow_downgrade,
             cincinnati: cfg.cincinnati,
             enabled: cfg.enabled,
             identity: cfg.identity,

--- a/tests/fixtures/00-config-sample.toml
+++ b/tests/fixtures/00-config-sample.toml
@@ -7,6 +7,7 @@ rollout_wariness = 0.5
 base_url= "http://cincinnati.example.com:80/"
 
 [updates]
+allow_downgrade = true
 enabled = false
 strategy = "fleet_lock"
 


### PR DESCRIPTION
This denies downgrades by default, but introduces a configuration
boolean `updates.allow_downgrade` (default: `false`) to disable
such logic for setups where deploying downgrades is fine.

Zincati only performs best-effort filtering based on the age-index
from the Cincinnati server, while the final enforcement is performed
by rpm-ostree based on real timestamps.

Closes: https://github.com/coreos/zincati/issues/87