### PR TITLE
dist/systemd: change binary path to /usr/libexec

### DIFF
--- a/dist/systemd/system/zincati.service
+++ b/dist/systemd/system/zincati.service
@@ -11,7 +11,7 @@ After=boot-complete.target
 User=zincati
 Group=zincati
 Environment=ZINCATI_VERBOSITY="-v"
-ExecStart=/usr/bin/zincati agent ${ZINCATI_VERBOSITY}
+ExecStart=/usr/libexec/zincati agent ${ZINCATI_VERBOSITY}
 Restart=on-failure
 RestartSec=10s
 


### PR DESCRIPTION
Change the path to the installed binary from `/usr/bin/zincati` to
`/usr/libexec/zincati`. This is done because `zincati` is not
currently intended to be run directly by users.

When installing Zincati and running Zincati through this unit, the
binary placed by `cargo install` should be moved to this location
under `/usr/libexec`.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/244