### PR TITLE
identity: send OS checksum to Cincinnati

### DIFF
--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -100,6 +100,7 @@ impl Identity {
     pub fn cincinnati_params(&self) -> HashMap<String, String> {
         let mut vars = HashMap::new();
         vars.insert("basearch".to_string(), self.basearch.clone());
+        vars.insert("os_checksum".to_string(), self.current_os.checksum.clone());
         vars.insert("os_version".to_string(), self.current_os.version.clone());
         vars.insert("group".to_string(), self.group.clone());
         vars.insert("node_uuid".to_string(), self.node_uuid.lower_hex());
@@ -149,6 +150,7 @@ mod tests {
         assert!(vars.contains_key("platform"));
         assert!(vars.contains_key("stream"));
         assert!(!vars.contains_key("node_uuid"));
+        assert!(!vars.contains_key("os_checksum"));
         assert!(!vars.contains_key("os_version"));
     }
 
@@ -162,6 +164,7 @@ mod tests {
         assert!(vars.contains_key("platform"));
         assert!(vars.contains_key("stream"));
         assert!(vars.contains_key("node_uuid"));
+        assert!(vars.contains_key("os_checksum"));
         assert!(vars.contains_key("os_version"));
     }
 }

--- a/src/rpm_ostree/mock_tests.rs
+++ b/src/rpm_ostree/mock_tests.rs
@@ -1,6 +1,6 @@
 use crate::cincinnati::Cincinnati;
-use crate::rpm_ostree::Release;
 use crate::identity::Identity;
+use crate::rpm_ostree::Release;
 use mockito::{self, Matcher};
 use tokio::runtime::current_thread as rt;
 


### PR DESCRIPTION
This adds back the OS checksum in Cincinnati client parameters,
which was dropped by mistake in https://github.com/coreos/zincati/pull/101.