### PR TITLE
rpm-ostree: do not update to already deployed releases

### DIFF
--- a/src/cincinnati/mock_tests.rs
+++ b/src/cincinnati/mock_tests.rs
@@ -1,6 +1,7 @@
 use crate::cincinnati::*;
 use crate::identity::Identity;
 use mockito::{self, Matcher};
+use std::collections::BTreeSet;
 use tokio::runtime::current_thread as rt;
 
 #[test]
@@ -16,7 +17,7 @@ fn test_empty_graph() {
     let client = Cincinnati {
         base_url: mockito::server_url(),
     };
-    let update = rt::block_on_all(client.next_update(&id));
+    let update = rt::block_on_all(client.next_update(&id, BTreeSet::new()));
     m_graph.assert();
 
     assert!(update.unwrap().is_none());

--- a/src/rpm_ostree/actor.rs
+++ b/src/rpm_ostree/actor.rs
@@ -4,6 +4,7 @@ use super::Release;
 use actix::prelude::*;
 use failure::Fallible;
 use log::trace;
+use std::collections::BTreeSet;
 
 /// Client actor for rpm-ostree.
 #[derive(Debug, Default, Clone)]
@@ -57,5 +58,22 @@ impl Handler<FinalizeDeployment> for RpmOstreeClient {
     fn handle(&mut self, msg: FinalizeDeployment, _ctx: &mut Self::Context) -> Self::Result {
         trace!("request to finalize release: {:?}", msg.release);
         super::cli_finalize::finalize_deployment(msg.release)
+    }
+}
+
+/// Request: query local deployments.
+#[derive(Debug, Clone)]
+pub struct QueryLocalDeployments {}
+
+impl Message for QueryLocalDeployments {
+    type Result = Fallible<BTreeSet<Release>>;
+}
+
+impl Handler<QueryLocalDeployments> for RpmOstreeClient {
+    type Result = Fallible<BTreeSet<Release>>;
+
+    fn handle(&mut self, _msg: QueryLocalDeployments, _ctx: &mut Self::Context) -> Self::Result {
+        trace!("request to list local deployments");
+        super::cli_status::local_deployments()
     }
 }

--- a/src/rpm_ostree/cli_status.rs
+++ b/src/rpm_ostree/cli_status.rs
@@ -5,6 +5,7 @@
 use super::Release;
 use failure::{bail, ensure, format_err, Fallible, ResultExt};
 use serde::Deserialize;
+use std::collections::BTreeSet;
 
 /// JSON output from `rpm-ostree status --json`
 #[derive(Debug, Deserialize)]
@@ -63,6 +64,17 @@ pub fn booted() -> Fallible<Release> {
     let status = status_json(true)?;
     let json = booted_json(status)?;
     Ok(json.into_release())
+}
+
+/// Return local deployments.
+pub fn local_deployments() -> Fallible<BTreeSet<Release>> {
+    let status = status_json(false)?;
+    let mut deployments = BTreeSet::<Release>::new();
+    for entry in status.deployments {
+        let release = entry.into_release();
+        deployments.insert(release);
+    }
+    Ok(deployments)
 }
 
 /// Return updates stream for booted deployment.

--- a/src/rpm_ostree/mock_tests.rs
+++ b/src/rpm_ostree/mock_tests.rs
@@ -1,7 +1,7 @@
 use crate::cincinnati::Cincinnati;
 use crate::identity::Identity;
-use crate::rpm_ostree::Release;
 use mockito::{self, Matcher};
+use std::collections::BTreeSet;
 use tokio::runtime::current_thread as rt;
 
 #[test]
@@ -45,11 +45,9 @@ fn test_simple_graph() {
     let client = Cincinnati {
         base_url: mockito::server_url(),
     };
-    let update = rt::block_on_all(client.fetch_update_hint(&id, true)).unwrap();
+    let update = rt::block_on_all(client.fetch_update_hint(&id, BTreeSet::new(), true)).unwrap();
     m_graph.assert();
 
-    let node = update.unwrap();
-    let next = Release::from_cincinnati(node).unwrap();
-
+    let next = update.unwrap();
     assert_eq!(next.version, "30.20190725.0")
 }

--- a/src/rpm_ostree/mod.rs
+++ b/src/rpm_ostree/mod.rs
@@ -4,7 +4,7 @@ mod cli_status;
 pub use cli_status::{basearch, booted, updates_stream};
 
 mod actor;
-pub use actor::{FinalizeDeployment, RpmOstreeClient, StageDeployment};
+pub use actor::{FinalizeDeployment, QueryLocalDeployments, RpmOstreeClient, StageDeployment};
 
 #[cfg(test)]
 mod mock_tests;


### PR DESCRIPTION
This improves rpm-ostree and Cincinnati logic to detect releases
already deployed locally, and to exclude them from the update targets
while evaluating the update graph.

This effectively stops Zincati from misbehaving whenever the booted
deployment is not the default or the most recent one.

Closes: https://github.com/coreos/zincati/issues/111