### PR TITLE
docs/dev: describe the Cincinnati protocol used by Fedora CoreOS

### DIFF
--- a/docs/development/cincinnati/protocol.md
+++ b/docs/development/cincinnati/protocol.md
@@ -1,0 +1,71 @@
+# Cincinnati for Fedora CoreOS
+
+Cincinnati is a protocol to provide "update hints" to clients, and it builds upon experiences with the [Omaha update protocol][google-omaha].
+It describes a particular method for representing transitions between releases of a project, allowing clients to apply updates in the right order.
+
+[google-omaha]: https://github.com/google/omaha/blob/v1.3.33.7/doc/ServerProtocolV3.md
+
+## Update Graph
+
+Cincinnati uses a [directed acyclic graph][dag] (DAG) to represent the complete set of valid update-paths.
+Each node in the graph is a release (with payload details) and each directed edge is a valid transition.
+
+[dag]: https://en.wikipedia.org/wiki/Directed_acyclic_graph
+
+## Clients
+
+Cincinnati clients are the final consumers of the update graph and payloads.
+A client periodically queries the Cincinnati service in order to fetch updates hints.
+Once it discovers at least a valid update edge, it may or may not decide to apply it locally (based on its configuration and heuristic).
+
+## Graph API
+
+### Request
+
+HTTP `GET` requests are used to fetch the DAG (as a JSON object) from the Graph API endpoint.
+Requests SHOULD be sent to the Graph API endpoint at `/v1/graph` and MUST include the following header:
+
+```
+Accept: application/json
+```
+
+Fedora CoreOS clients MUST provide additional details as URL query parameters in the request.
+
+|        Key       | Optional | Description                                           |
+|------------------|----------|-------------------------------------------------------|
+| basearch         | required | base architecture (non-empty string)                  |
+| stream           | required | client-selected update stream (non-empty string)      |
+| node_uuid        | optional | application-specific unique-identifier for the client |
+| os_version       | optional | current OS version                                    |
+| os_checksum      | optional | current OS checksum                                   |
+| group            | optional | update group                                          |
+| rollout_wariness | optional | client wariness to update rollout                     |
+| platform         | optional | client platform                                       |
+
+### Response
+
+A positive response to the `/v1/graph` endpoint MUST be a JSON representation of the update graph.
+Each known release is represented by an entry in the top-level `nodes` array.
+Each of these entries includes the release version label, a payload identifier and any additional metadata. Each entry follows this schema:
+
+|    Key   | Optional | Description                                                                             |
+|----------|----------|-----------------------------------------------------------------------------------------|
+| version  | required | the version of the release, as a unique (across "nodes" array) non-empty JSON string    |
+| payload  | required | payload identifier, as a JSON string                                                    |
+| metadata | required | a string-\>string map conveying arbitrary information about the release                 |
+
+Allowed transitions between releases are represented as a top-level `edges` array, where each entry is an array-tuple.
+Each of these tuples has two fields: the index of the starting node, and the index of the target node. Both are non-negative integers, ranging from 0 to `len(nodes)-1`.
+
+For an example of a valid JSON document from a graph response, see [response.json](./response.json).
+
+### Errors
+
+Errors on the `/v1/graph` endpoint SHOULD be returned to the client as JSON objects, with a 4xx or 5xx HTTP status code.
+Error values carry a type-identifier and a textual description, according to the following schema:
+
+|  Key   | Optional | Description                                                  |
+|--------|----------|--------------------------------------------------------------|
+| kind   | required | error type identifier, as a non-empty JSON string            |
+| value  | required | human-friendly error description, as a non-empty JSON string |
+

--- a/docs/development/cincinnati/response.json
+++ b/docs/development/cincinnati/response.json
@@ -1,0 +1,42 @@
+{
+  "nodes": [
+    {
+      "version": "32.20200517.1.0",
+      "metadata": {
+        "org.fedoraproject.coreos.releases.age_index": "0",
+        "org.fedoraproject.coreos.scheme": "checksum"
+      },
+      "payload": "7c23c4735fb3c541586f0a4d3ca956ef93ef7d76f00a19bccf51460bafa7ee97"
+    },
+    {
+      "version": "32.20200601.1.0",
+      "metadata": {
+        "org.fedoraproject.coreos.scheme": "checksum",
+        "org.fedoraproject.coreos.releases.age_index": "1"
+      },
+      "payload": "8cffe35be831fa2601d315002cb39fb22509a4e7d3db10e61f880523f69b3bf6"
+    },
+    {
+      "version": "32.20200601.1.1",
+      "metadata": {
+        "org.fedoraproject.coreos.releases.age_index": "2",
+        "org.fedoraproject.coreos.scheme": "checksum",
+        "org.fedoraproject.coreos.updates.start_epoch": "1591279200",
+        "org.fedoraproject.coreos.updates.start_value": "0",
+        "org.fedoraproject.coreos.updates.rollout": "true",
+        "org.fedoraproject.coreos.updates.duration_minutes": "2880"
+      },
+      "payload": "08040bebbab87a3343a281f94bb68010df618eb6ce6ac3d4230d2595959b5da1"
+    }
+  ],
+  "edges": [
+    [
+      0,
+      2
+    ],
+    [
+      1,
+      2
+    ]
+  ]
+}


### PR DESCRIPTION
This adds dev-docs describing how the Cincinati protocol works and
how it is used by Fedora CoreOS.
This covers both client-side and server-side additional constraints
specific to FCOS.