### PR TITLE
strategy: add FleetLock cluster-wide reboot coordination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,6 +2446,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liboverdrop 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsystemd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ toml = "^0.5.3"
 url_serde = "^0.2.0"
 
 [dev-dependencies]
+http = "^0.1"
 mockito = "^0.20"
 proptest = "^0.9"
 tokio = "^0.1"

--- a/dist/config.d/30-updates-strategy.toml
+++ b/dist/config.d/30-updates-strategy.toml
@@ -1,0 +1,12 @@
+# How to finalize update.
+[updates]
+
+# String to customize update strategy.
+# Default strategy is to immediately finalize updates as soon as available,
+# and reboot the node.
+strategy = "immediate"
+
+# Update strategy which uses an external reboot coordinator (FleetLock protocol).
+#strategy = "fleet_lock"
+# Base URL for the FleetLock service.
+#fleet_lock.base_url = "https://fleet-lock.example.com/"

--- a/src/config/fragments.rs
+++ b/src/config/fragments.rs
@@ -38,23 +38,15 @@ pub(crate) struct UpdateFragment {
     pub(crate) enabled: Option<bool>,
     /// Update strategy (default: immediate).
     pub(crate) strategy: Option<String>,
-    /// `periodic` strategy config.
-    pub(crate) periodic: Option<UpPeriodicFragment>,
-    /// `remote_http` strategy config.
-    pub(crate) remote_http: Option<UpHttpFragment>,
+    /// `fleet_lock` strategy config.
+    pub(crate) fleet_lock: Option<UpdateFleetLock>,
 }
 
-/// Config fragment for `remote_http` update strategy.
+/// Config fragment for `fleet_lock` update strategy.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
-pub(crate) struct UpHttpFragment {
+pub(crate) struct UpdateFleetLock {
     /// Base URL for the remote semaphore manager.
     pub(crate) base_url: Option<String>,
-}
-
-/// Config fragment for `periodic` update strategy.
-#[derive(Debug, Deserialize, PartialEq, Eq)]
-pub(crate) struct UpPeriodicFragment {
-    // TODO(lucab): define entries.
 }
 
 #[cfg(test)]
@@ -72,7 +64,7 @@ mod tests {
 
         let expected = ConfigFragment {
             cincinnati: Some(CincinnatiFragment {
-                base_url: Some("http://example.com:80/".to_string()),
+                base_url: Some("http://cincinnati.example.com:80/".to_string()),
             }),
             identity: Some(IdentityFragment {
                 group: Some("workers".to_string()),
@@ -81,9 +73,10 @@ mod tests {
             }),
             updates: Some(UpdateFragment {
                 enabled: Some(false),
-                strategy: Some("immediate".to_string()),
-                periodic: None,
-                remote_http: None,
+                strategy: Some("fleet_lock".to_string()),
+                fleet_lock: Some(UpdateFleetLock {
+                    base_url: Some("http://fleet-lock.example.com:8080/".to_string()),
+                }),
             }),
         };
 

--- a/src/config/inputs.rs
+++ b/src/config/inputs.rs
@@ -130,20 +130,24 @@ pub(crate) struct UpdateInput {
     pub(crate) enabled: bool,
     /// Update strategy.
     pub(crate) strategy: String,
-    /// `remote_http` strategy config.
-    pub(crate) remote_http: StratHttpInput,
-    /// `periodic` strategy config.
-    pub(crate) periodic: StratPeriodicInput,
+    /// `fleet_lock` strategy config.
+    pub(crate) fleet_lock: FleetLockInput,
+}
+
+/// Config for "fleet_lock" strategy.
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct FleetLockInput {
+    /// Base URL (template) for the FleetLock service.
+    pub(crate) base_url: String,
 }
 
 impl UpdateInput {
     fn from_fragments(fragments: Vec<fragments::UpdateFragment>) -> Self {
         let mut enabled = true;
         let mut strategy = String::new();
-        let mut remote_http = StratHttpInput {
+        let mut fleet_lock = FleetLockInput {
             base_url: String::new(),
         };
-        let periodic = StratPeriodicInput {};
 
         for snip in fragments {
             if let Some(e) = snip.enabled {
@@ -152,9 +156,9 @@ impl UpdateInput {
             if let Some(s) = snip.strategy {
                 strategy = s;
             }
-            if let Some(remote) = snip.remote_http {
-                if let Some(b) = remote.base_url {
-                    remote_http.base_url = b;
+            if let Some(fl) = snip.fleet_lock {
+                if let Some(b) = fl.base_url {
+                    fleet_lock.base_url = b;
                 }
             }
         }
@@ -162,19 +166,7 @@ impl UpdateInput {
         Self {
             enabled,
             strategy,
-            remote_http,
-            periodic,
+            fleet_lock,
         }
     }
 }
-
-/// Config snippet for `remote_http` finalizer strategy.
-#[derive(Debug, Serialize)]
-pub(crate) struct StratHttpInput {
-    /// Base URL (template) for the remote semaphore manager.
-    pub(crate) base_url: String,
-}
-
-/// Config snippet for `periodic` strategy.
-#[derive(Debug, Serialize)]
-pub(crate) struct StratPeriodicInput {}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -52,7 +52,7 @@ impl Settings {
         let enabled = cfg.updates.enabled;
         let identity = Identity::with_config(cfg.identity)
             .context("failed to validate agent identity configuration")?;
-        let strategy = UpdateStrategy::with_config(cfg.updates)
+        let strategy = UpdateStrategy::with_config(cfg.updates, &identity)
             .context("failed to validate update-strategy configuration")?;
         let cincinnati = Cincinnati::with_config(cfg.cincinnati, &identity)
             .context("failed to validate cincinnati configuration")?;

--- a/src/fleet_lock/mock_tests.rs
+++ b/src/fleet_lock/mock_tests.rs
@@ -1,0 +1,106 @@
+use crate::fleet_lock::*;
+use crate::identity::Identity;
+use mockito::Matcher;
+use tokio::runtime::current_thread as rt;
+
+#[test]
+fn test_pre_reboot_lock() {
+    let body = r#"
+{
+  "client_params": {
+    "node_uuid": "e0f3745b108f471cbd4883c6fbed8cdd",
+    "group": "mock-workers"
+  }
+}
+"#;
+    let m_pre_reboot = mockito::mock("POST", Matcher::Exact(format!("/{}", V1_PRE_REBOOT)))
+        .match_header("fleet-lock-protocol", "true")
+        .match_body(Matcher::PartialJsonString(body.to_string()))
+        .with_status(200)
+        .create();
+
+    let id = Identity::mock_default();
+    let client = ClientBuilder::new(mockito::server_url(), &id)
+        .build()
+        .unwrap();
+    let res = rt::block_on_all(client.pre_reboot());
+    m_pre_reboot.assert();
+
+    let lock = res.unwrap();
+    assert_eq!(lock, true);
+}
+
+#[test]
+fn test_pre_reboot_error() {
+    let body = r#"
+{
+  "kind": "f1",
+  "value": "pre-reboot failure"
+}
+"#;
+    let m_pre_reboot = mockito::mock("POST", Matcher::Exact(format!("/{}", V1_PRE_REBOOT)))
+        .match_header("fleet-lock-protocol", "true")
+        .with_status(404)
+        .with_body(body)
+        .create();
+
+    let id = Identity::mock_default();
+    let client = ClientBuilder::new(mockito::server_url(), &id)
+        .build()
+        .unwrap();
+    let res = rt::block_on_all(client.pre_reboot());
+    m_pre_reboot.assert();
+
+    let _rejection = res.unwrap_err();
+}
+
+#[test]
+fn test_steady_state_lock() {
+    let body = r#"
+{
+  "client_params": {
+    "node_uuid": "e0f3745b108f471cbd4883c6fbed8cdd",
+    "group": "mock-workers"
+  }
+}
+"#;
+    let m_steady_state = mockito::mock("POST", Matcher::Exact(format!("/{}", V1_STEADY_STATE)))
+        .match_header("fleet-lock-protocol", "true")
+        .match_body(Matcher::PartialJsonString(body.to_string()))
+        .with_status(200)
+        .create();
+
+    let id = Identity::mock_default();
+    let client = ClientBuilder::new(mockito::server_url(), &id)
+        .build()
+        .unwrap();
+    let res = rt::block_on_all(client.steady_state());
+    m_steady_state.assert();
+
+    let unlock = res.unwrap();
+    assert_eq!(unlock, true);
+}
+
+#[test]
+fn test_steady_state_error() {
+    let body = r#"
+{
+  "kind": "f1",
+  "value": "pre-reboot failure"
+}
+"#;
+    let m_steady_state = mockito::mock("POST", Matcher::Exact(format!("/{}", V1_STEADY_STATE)))
+        .match_header("fleet-lock-protocol", "true")
+        .with_status(404)
+        .with_body(body)
+        .create();
+
+    let id = Identity::mock_default();
+    let client = ClientBuilder::new(mockito::server_url(), &id)
+        .build()
+        .unwrap();
+    let res = rt::block_on_all(client.steady_state());
+    m_steady_state.assert();
+
+    let _rejection = res.unwrap_err();
+}

--- a/src/fleet_lock/mod.rs
+++ b/src/fleet_lock/mod.rs
@@ -1,0 +1,261 @@
+//! Asynchronous FleetLock client, remote lock management.
+//!
+//! This module implements a client for FleetLock, a bare HTTP
+//! protocol for managing cluster-wide reboot via a remote
+//! lock manager. Protocol specification is currently in progress at
+//! https://github.com/coreos/airlock/pull/1.
+
+use crate::identity::Identity;
+use failure::{Error, Fail, Fallible, ResultExt};
+use futures::future;
+use futures::prelude::*;
+use reqwest::r#async as asynchro;
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+mod mock_tests;
+
+/// FleetLock pre-reboot API path endpoint (v1).
+static V1_PRE_REBOOT: &str = "v1/pre-reboot";
+
+/// FleetLock steady-state API path endpoint (v1).
+static V1_STEADY_STATE: &str = "v1/steady-state";
+
+/// Error from lock manager.
+#[derive(Clone, Debug, Fail, Deserialize, Serialize, PartialEq, Eq)]
+pub struct LockRejection {
+    /// Endpoint that returned this rejection/error.
+    #[serde(skip)]
+    endpoint: String,
+    /// HTTP status code returned by the server.
+    #[serde(skip)]
+    status: reqwest::StatusCode,
+    /// Machine-friendly brief error kind.
+    kind: String,
+    /// Human-friendly detailed error explanation.
+    value: String,
+}
+
+impl std::fmt::Display for LockRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "lock manager {} rejection, code {}: {}",
+            self.endpoint,
+            self.status.as_u16(),
+            self.value
+        )
+    }
+}
+
+/// Client to make outgoing API requests.
+#[derive(Clone, Debug, Serialize)]
+pub struct Client {
+    /// Base URL for API endpoint.
+    #[serde(skip)]
+    api_base: reqwest::Url,
+    /// Asynchronous reqwest client.
+    #[serde(skip)]
+    hclient: asynchro::Client,
+    /// Request body.
+    body: String,
+}
+
+impl Client {
+    /// Try to lock a semaphore slot on the remote manager.
+    ///
+    /// It returns `true` if the operation succeeds, or a `LockRejection`
+    /// with the relevant error explanation.
+    pub fn pre_reboot(&self) -> impl Future<Item = bool, Error = Error> {
+        let req = self.new_request(Method::POST, V1_PRE_REBOOT);
+        future::result(req)
+            .and_then(|req| req.send().from_err())
+            .and_then(|resp| Self::map_response(resp, "pre-reboot").from_err())
+    }
+
+    /// Try to unlock a semaphore slot on the remote manager.
+    ///
+    /// It returns `true` if the operation succeeds, or a `LockRejection`
+    /// with the relevant error explanation.
+    pub fn steady_state(&self) -> impl Future<Item = bool, Error = Error> {
+        let req = self.new_request(Method::POST, V1_STEADY_STATE);
+        future::result(req)
+            .and_then(|req| req.send().from_err())
+            .and_then(|resp| Self::map_response(resp, "steady-state").from_err())
+    }
+
+    /// Return a request builder for the target URL, with proper parameters set.
+    fn new_request<S: AsRef<str>>(
+        &self,
+        method: reqwest::Method,
+        url_suffix: S,
+    ) -> Fallible<asynchro::RequestBuilder> {
+        let url = self.api_base.clone().join(url_suffix.as_ref())?;
+        let builder = self
+            .hclient
+            .request(method, url)
+            .body(self.body.clone())
+            .header("fleet-lock-protocol", "true");
+        Ok(builder)
+    }
+
+    /// Map an HTTP response to a service result.
+    fn map_response(
+        mut response: asynchro::Response,
+        api: &str,
+    ) -> Box<dyn Future<Item = bool, Error = LockRejection>> {
+        // On success, short-circuit to `true`.
+        let status = response.status();
+        if status.is_success() {
+            return Box::new(future::ok(true));
+        }
+
+        // On error, decode failure details (or synthesize a generic error).
+        let endpoint = api.to_string();
+        let rejection = response
+            .json::<LockRejection>()
+            .then(move |r| {
+                if let Ok(mut rej) = r {
+                    rej.status = status;
+                    rej.endpoint = endpoint;
+                    Err(rej)
+                } else {
+                    Err(LockRejection {
+                        status,
+                        endpoint,
+                        kind: format!("generic_http_{}", status.as_u16()),
+                        value: "(unknown server error)".to_string(),
+                    })
+                }
+            })
+            // TODO(lucab): this is likely not needed and can eventually be dropped,
+            //  see https://github.com/coreos/zincati/issues/35
+            .map(|_: LockRejection| false);
+        Box::new(rejection)
+    }
+}
+
+/// Client builder.
+#[derive(Clone, Debug)]
+pub struct ClientBuilder {
+    /// Base URL for API endpoint (mandatory).
+    api_base: String,
+    /// Asynchronous reqwest client (custom).
+    hclient: Option<asynchro::Client>,
+    /// Client identity.
+    client_identity: ClientIdentity,
+}
+
+/// Client identity, for requests body.
+#[derive(Clone, Debug, Serialize)]
+pub struct ClientIdentity {
+    client_params: ClientParameters,
+}
+
+/// Client parameters.
+#[derive(Clone, Debug, Serialize)]
+pub struct ClientParameters {
+    /// Node identifier, for lock ownership.
+    node_uuid: String,
+    /// Reboot group, for role-specific remote configuration.
+    group: String,
+}
+
+impl ClientBuilder {
+    /// Return a new client builder for the given base API endpoint URL.
+    pub(crate) fn new<T>(api_base: T, identity: &Identity) -> Self
+    where
+        T: Into<String>,
+    {
+        Self {
+            api_base: api_base.into(),
+            hclient: None,
+            client_identity: ClientIdentity {
+                client_params: ClientParameters {
+                    node_uuid: identity.node_uuid.lower_hex(),
+                    group: identity.group.clone(),
+                },
+            },
+        }
+    }
+
+    /// Set (or reset) the HTTP client to use.
+    #[allow(dead_code)]
+    pub fn http_client(self, hclient: Option<asynchro::Client>) -> Self {
+        let mut builder = self;
+        builder.hclient = hclient;
+        builder
+    }
+
+    /// Build a client with specified parameters.
+    pub fn build(self) -> Fallible<Client> {
+        let hclient = match self.hclient {
+            Some(client) => client,
+            None => asynchro::ClientBuilder::new().build()?,
+        };
+
+        let api_base = reqwest::Url::parse(&self.api_base)
+            .context(format!("failed to parse '{}'", &self.api_base))?;
+        if self.client_identity.client_params.group.is_empty() {
+            failure::bail!("missing group value");
+        }
+        let body = serde_json::to_string_pretty(&self.client_identity)?;
+        let client = Client {
+            api_base,
+            hclient,
+            body,
+        };
+        Ok(client)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::response::Response;
+    use http::status::StatusCode;
+    use tokio::runtime::current_thread as rt;
+
+    #[test]
+    fn test_service_rejection_display() {
+        let err_body = r#"
+{
+  "kind": "failure_foo",
+  "value": "failed to perform foo"
+}
+"#;
+        let response = Response::builder().status(466).body(err_body).unwrap();
+        let fut_rejection = Client::map_response(response.into(), "test-ep");
+        let rejection = rt::block_on_all(fut_rejection).unwrap_err();
+        let expected_rejection = LockRejection {
+            status: StatusCode::from_u16(466).unwrap(),
+            endpoint: "test-ep".to_string(),
+            kind: "failure_foo".to_string(),
+            value: "failed to perform foo".to_string(),
+        };
+        assert_eq!(&rejection, &expected_rejection);
+
+        let msg = rejection.to_string();
+        let expected_msg = "lock manager test-ep rejection, code 466: failed to perform foo";
+        assert_eq!(&msg, expected_msg);
+    }
+
+    #[test]
+    fn test_http_error_display() {
+        let response = Response::builder().status(433).body("").unwrap();
+        let fut_rejection = Client::map_response(response.into(), "test-ep");
+        let rejection = rt::block_on_all(fut_rejection).unwrap_err();
+        let expected_rejection = LockRejection {
+            status: StatusCode::from_u16(433).unwrap(),
+            endpoint: "test-ep".to_string(),
+            kind: "generic_http_433".to_string(),
+            value: "(unknown server error)".to_string(),
+        };
+        assert_eq!(&rejection, &expected_rejection);
+
+        let msg = rejection.to_string();
+        let expected_msg = "lock manager test-ep rejection, code 433: (unknown server error)";
+        assert_eq!(&msg, expected_msg);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ mod cincinnati;
 mod cli;
 /// File-based configuration.
 mod config;
+/// FleetLock client.
+mod fleet_lock;
 /// Agent identity.
 mod identity;
 /// Metrics service.

--- a/src/strategy/fleet_lock.rs
+++ b/src/strategy/fleet_lock.rs
@@ -1,0 +1,101 @@
+//! Strategy for fleet-wide coordinated updates (FleetLock protocol).
+
+use crate::config::inputs;
+use crate::fleet_lock::{Client, ClientBuilder};
+use crate::identity::Identity;
+use failure::{Error, Fallible};
+use futures::future;
+use futures::prelude::*;
+use log::trace;
+use serde::Serialize;
+
+/// Strategy for remote coordination.
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct StrategyFleetLock {
+    /// Asynchronous client.
+    pub(crate) client: Client,
+}
+
+impl StrategyFleetLock {
+    /// Build a new FleetLock strategy.
+    pub fn new(cfg: inputs::UpdateInput, identity: &Identity) -> Fallible<Self> {
+        // Substitute templated key with agent runtime values.
+        let base_url = if envsubst::is_templated(&cfg.fleet_lock.base_url) {
+            let context = identity.url_variables();
+            envsubst::validate_vars(&context)?;
+            envsubst::substitute(cfg.fleet_lock.base_url, &context)?
+        } else {
+            cfg.fleet_lock.base_url
+        };
+
+        if base_url.is_empty() {
+            failure::bail!("empty fleet_lock base URL");
+        }
+        log::info!("remote fleet_lock reboot manager: {}", &base_url);
+
+        let builder = ClientBuilder::new(base_url, identity);
+        let client = builder.build()?;
+        let strategy = Self { client };
+        Ok(strategy)
+    }
+
+    /// Check if finalization is allowed.
+    pub(crate) fn can_finalize(&self) -> Box<dyn Future<Item = bool, Error = Error>> {
+        trace!("fleet_lock strategy, checking whether update can be finalized");
+
+        Box::new(self.client.pre_reboot())
+    }
+
+    /// Try to report steady state.
+    pub(crate) fn report_steady(&self) -> Box<dyn Future<Item = bool, Error = Error>> {
+        trace!("fleet_lock strategy, attempting to report steady");
+
+        Box::new(self.client.steady_state())
+    }
+
+    /// Check if fetching updates is allowed
+    pub(crate) fn can_check_and_fetch(&self) -> Box<dyn Future<Item = bool, Error = Error>> {
+        trace!("fleet_lock strategy, can check updates: {}", true);
+
+        // TODO(lucab): https://github.com/coreos/zincati/issues/35
+        let res = future::ok(true);
+        Box::new(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::inputs::{FleetLockInput, UpdateInput};
+    use crate::identity::Identity;
+
+    #[test]
+    fn test_url_simple() {
+        let id = Identity::mock_default();
+        let input = UpdateInput {
+            enabled: true,
+            strategy: "fleet_lock".to_string(),
+            fleet_lock: FleetLockInput {
+                base_url: "https://example.com".to_string(),
+            },
+        };
+
+        let res = StrategyFleetLock::new(input, &id);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_empty_url() {
+        let id = Identity::mock_default();
+        let input = UpdateInput {
+            enabled: true,
+            strategy: "fleet_lock".to_string(),
+            fleet_lock: FleetLockInput {
+                base_url: String::new(),
+            },
+        };
+
+        let res = StrategyFleetLock::new(input, &id);
+        assert!(res.is_err());
+    }
+}

--- a/src/strategy/immediate.rs
+++ b/src/strategy/immediate.rs
@@ -17,7 +17,7 @@ pub(crate) struct StrategyImmediate {
 
 impl StrategyImmediate {
     /// Check if finalization is allowed.
-    pub(crate) fn can_finalize(&self) -> impl Future<Item = bool, Error = Error> {
+    pub(crate) fn can_finalize(&self) -> Box<dyn Future<Item = bool, Error = Error>> {
         trace!(
             "immediate strategy, can finalize updates: {}",
             self.finalize

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -9,18 +9,23 @@ use futures::prelude::*;
 use log::error;
 use serde::Serialize;
 
+mod fleet_lock;
+pub(crate) use fleet_lock::StrategyFleetLock;
+
 mod immediate;
 pub(crate) use immediate::StrategyImmediate;
 
 #[derive(Clone, Debug, Serialize)]
 pub(crate) enum UpdateStrategy {
+    FleetLock(StrategyFleetLock),
     Immediate(StrategyImmediate),
 }
 
 impl UpdateStrategy {
     /// Try to parse config inputs into a valid strategy.
-    pub(crate) fn with_config(cfg: inputs::UpdateInput) -> Fallible<Self> {
+    pub(crate) fn with_config(cfg: inputs::UpdateInput, identity: &Identity) -> Fallible<Self> {
         let strategy = match cfg.strategy.as_ref() {
+            "fleet_lock" => UpdateStrategy::new_fleet_lock(cfg, identity)?,
             "immediate" => UpdateStrategy::new_immediate()?,
             "" => UpdateStrategy::default(),
             x => bail!("unsupported strategy '{}'", x),
@@ -34,7 +39,8 @@ impl UpdateStrategy {
         _identity: &Identity,
     ) -> Box<dyn Future<Item = bool, Error = ()>> {
         let lock = match self {
-            UpdateStrategy::Immediate(i) => i.can_finalize(),
+            UpdateStrategy::FleetLock(s) => s.can_finalize(),
+            UpdateStrategy::Immediate(s) => s.can_finalize(),
         }
         .map_err(|e| error!("{}", e));
         Box::new(lock)
@@ -46,7 +52,8 @@ impl UpdateStrategy {
         _identity: &Identity,
     ) -> Box<dyn Future<Item = bool, Error = ()>> {
         let unlock = match self {
-            UpdateStrategy::Immediate(i) => i.report_steady(),
+            UpdateStrategy::FleetLock(s) => s.report_steady(),
+            UpdateStrategy::Immediate(s) => s.report_steady(),
         }
         .map_err(|e| error!("{}", e));
         Box::new(unlock)
@@ -58,15 +65,23 @@ impl UpdateStrategy {
         _identity: &Identity,
     ) -> Box<dyn Future<Item = bool, Error = ()>> {
         let can_check = match self {
-            UpdateStrategy::Immediate(i) => i.can_check_and_fetch(),
+            UpdateStrategy::FleetLock(s) => s.can_check_and_fetch(),
+            UpdateStrategy::Immediate(s) => s.can_check_and_fetch(),
         }
         .map_err(|e| error!("{}", e));
         Box::new(can_check)
     }
 
+    /// Build a new "immediate" strategy.
     fn new_immediate() -> Fallible<Self> {
         let immediate = StrategyImmediate::default();
         Ok(UpdateStrategy::Immediate(immediate))
+    }
+
+    /// Build a new "fleet_lock" strategy.
+    fn new_fleet_lock(cfg: inputs::UpdateInput, identity: &Identity) -> Fallible<Self> {
+        let fleet_lock = StrategyFleetLock::new(cfg, identity)?;
+        Ok(UpdateStrategy::FleetLock(fleet_lock))
     }
 }
 

--- a/tests/fixtures/00-config-sample.toml
+++ b/tests/fixtures/00-config-sample.toml
@@ -4,8 +4,11 @@ node_uuid = "27e3ac02af3946af995c9940e18b0cce"
 rollout_wariness = 0.5
 
 [cincinnati]
-base_url= "http://example.com:80/"
+base_url= "http://cincinnati.example.com:80/"
 
 [updates]
 enabled = false
-strategy = "immediate"
+strategy = "fleet_lock"
+
+[updates.fleet_lock]
+base_url= "http://fleet-lock.example.com:8080/"


### PR DESCRIPTION
This adds configuration and logic for a `fleet_lock` update strategy,
which allows cluster-wide reboot coordination.

Protocol: https://github.com/coreos/airlock/pull/1
Docs: https://github.com/coreos/zincati/pull/134
Closes: https://github.com/coreos/zincati/issues/37