### PR TITLE
zincati: update trait object syntax

### DIFF
--- a/src/cincinnati/mod.rs
+++ b/src/cincinnati/mod.rs
@@ -75,7 +75,7 @@ impl Cincinnati {
         &self,
         id: &Identity,
         can_check: bool,
-    ) -> Box<Future<Item = Option<Node>, Error = ()>> {
+    ) -> Box<dyn Future<Item = Option<Node>, Error = ()>> {
         if !can_check {
             return Box::new(futures::future::ok(None));
         }
@@ -91,7 +91,7 @@ impl Cincinnati {
     }
 
     /// Get the next update.
-    fn next_update(&self, id: &Identity) -> Box<Future<Item = Option<Node>, Error = Error>> {
+    fn next_update(&self, id: &Identity) -> Box<dyn Future<Item = Option<Node>, Error = Error>> {
         let params = id.cincinnati_params();
         let base_checksum = id.current_os.checksum.clone();
         let client = client::ClientBuilder::new(self.base_url.to_string())

--- a/src/strategy/immediate.rs
+++ b/src/strategy/immediate.rs
@@ -27,14 +27,14 @@ impl StrategyImmediate {
         Box::new(immediate)
     }
 
-    pub(crate) fn report_steady(&self) -> Box<Future<Item = bool, Error = Error>> {
+    pub(crate) fn report_steady(&self) -> Box<dyn Future<Item = bool, Error = Error>> {
         trace!("immediate strategy, report steady: {}", true);
 
         let immediate = future::ok(true);
         Box::new(immediate)
     }
 
-    pub(crate) fn can_check_and_fetch(&self) -> Box<Future<Item = bool, Error = Error>> {
+    pub(crate) fn can_check_and_fetch(&self) -> Box<dyn Future<Item = bool, Error = Error>> {
         trace!("immediate strategy, can check updates: {}", self.check);
 
         let immediate = future::ok(self.check);

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -32,7 +32,7 @@ impl UpdateStrategy {
     pub(crate) fn can_finalize(
         &self,
         _identity: &Identity,
-    ) -> Box<Future<Item = bool, Error = ()>> {
+    ) -> Box<dyn Future<Item = bool, Error = ()>> {
         let lock = match self {
             UpdateStrategy::Immediate(i) => i.can_finalize(),
         }
@@ -44,7 +44,7 @@ impl UpdateStrategy {
     pub(crate) fn report_steady(
         &self,
         _identity: &Identity,
-    ) -> Box<Future<Item = bool, Error = ()>> {
+    ) -> Box<dyn Future<Item = bool, Error = ()>> {
         let unlock = match self {
             UpdateStrategy::Immediate(i) => i.report_steady(),
         }
@@ -56,7 +56,7 @@ impl UpdateStrategy {
     pub(crate) fn can_check_and_fetch(
         &self,
         _identity: &Identity,
-    ) -> Box<Future<Item = bool, Error = ()>> {
+    ) -> Box<dyn Future<Item = bool, Error = ()>> {
         let can_check = match self {
             UpdateStrategy::Immediate(i) => i.can_check_and_fetch(),
         }


### PR DESCRIPTION
This fixes several old-style trait object signatures, to avoid all
warnings like "trait objects without an explicit `dyn` are deprecated".