### PR TITLE
dist/systemd: don't start Zincati if booted as a live system

### DIFF
--- a/dist/systemd/system/zincati.service
+++ b/dist/systemd/system/zincati.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Zincati Update Agent
 Documentation=https://github.com/coreos/zincati
+# Skip live systems not meant to be auto-updated (e.g. live PXE, live ISO)
+ConditionPathExists=!/run/ostree-live
 After=network.target
 # Wait for the boot to be marked as successful. In cluster contexts,
 # this prevents rolling out broken updates to all nodes in the fleet.


### PR DESCRIPTION
...such as on a live system.  We can't perform updates in that case.