### PR TITLE
Release 0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.5"
+version = "0.0.6-alpha.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.5-alpha.0"
+version = "0.0.5"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.5"
+version = "0.0.6-alpha.0"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.5-alpha.0"
+version = "0.0.5"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]


### PR DESCRIPTION
 * github: add feature template
 * zincati: improve logging and metrics
 * identity: send OS checksum to Cincinnati
 * identity: track rollout wariness in metrics
 * dist/systemd: change binary path to /usr/libexec
 * identity: provide OS version to Cincinnati
 * rpm_ostree: add release ordering based on age-index
 * docs: update LICENSE content from apache.org
 * identity: allow setting rollout wariness
 * cargo: update dependencies to latest versions

Ref: https://github.com/coreos/zincati/milestone/1?closed=1