### PR TITLE
docs: explain lock-based updates strategy

### DIFF
--- a/docs/usage/auto-updates.md
+++ b/docs/usage/auto-updates.md
@@ -35,6 +35,26 @@ It is recommended to setup and monitor canary nodes, but otherwise normal worker
 
 The default and recommended configuration does not set any static wariness value on Zincati side, leaving rollout decisions to Cincinnati backend.
 
+## Strategies for updates finalization
+
+Zincati actively tries to detect and stage new updates whenever they become available.
+Once a new payload has been locally staged, a machine reboot is required in order to atomically apply the update to the system as a whole.
+
+Rebooting a machine does affect any workloads running on the machine at that time, and can potentially impact services across a whole cluster of nodes.
+For such reason, Zincati allows the user to control when a node is allowed to reboot to finalize an auto-update.
+
+The following finalization strategies are currently available:
+ * immediately reboot to apply an update, as soon as it is downloaded and staged locally (`immediate` strategy, see [relevant documentation][strategy-immediate]).
+ * use an external lock-manager to reboot a fleet of machines in a coordinated way (`fleet_lock` strategy, see [relevant documentation][strategy-fleet_lock]).
+
+By default, the `immediate` strategy is used in order to proactively keep machines up-to-date.
+
+For further documentation on configurations, check the [updates strategy][updates-strategy] documentation.
+
+[strategy-immediate]: updates-strategy.md#immediate-strategy
+[strategy-fleet_lock]: updates-strategy.md#lock-based-strategy
+[updates-strategy]: updates-strategy.md
+
 ## Disabling auto-updates
 
 To disable auto-updates, a configuration snippet containing the following has to be installed on the system:

--- a/docs/usage/updates-strategy.md
+++ b/docs/usage/updates-strategy.md
@@ -1,0 +1,58 @@
+# Updates strategy
+
+To minimize service disruption, Zincati allows administrators to control when machines are allowed to reboot and finalize auto-updates.
+
+Several updates strategies are supported, which can be configured at runtime via configuration snippets as shown below.
+If not otherwise configured, the default updates strategy resolves to `immediate`.
+
+# Immediate strategy
+
+The simplest updates strategy consists of minimal logic to immediately finalize an update as soon as it is staged locally.
+
+For configuration purposes, such strategy is labeled `immediate` and takes no additional configuration parameters.
+
+This strategy can be enabled via a configuration snippet like the following:
+
+```toml
+[updates]
+strategy = "immediate"
+```
+
+The `immediate` strategy is an aggressive finalization method which is biased towards finalizing updates as soon as possible, and it is only aware of node-local state.
+
+Such an approach is only recommended for environments where temporary service interruption are not problematic, or there is no need for more complex reboot scheduling.
+
+# Lock-based strategy
+
+In case of a fleet of machines grouped into a cluster, it is often required to orchestrate reboots so that hosted services are not disrupted when single nodes are rebooting to finalize updates.
+In this case it is helpful to have an external orchestrator managing reboots cluster-wide, and having each machine trying to lock (and unlock) a reboot slot with the centralized lock-manager.
+
+Several distributed databases and lock-managers exist for such purpose, each one with a specific remote API for clients and a variety of transport mechanisms.
+Zincati does not mandate any specific lock-manager or database, but instead it uses a simple HTTP-based protocol modeling a distributed counting semaphore with recursive locking, called [FleetLock][fleet_lock], 
+
+In short, it consists of two operations:
+ * lock: before rebooting, a reboot slot must be locked (and confirmed) by the lock-manager.
+ * unlock: after rebooting, any reboot slot owned by the node must be unlocked (and confirmed) by the lock-manager before proceeding further.
+
+This protocol is not coupled to any specific backend, and can be implemented on top of any suitable database.
+As an example, [airlock] is a free-software project which implements such protocol on top of [etcd3].
+
+For configuration purposes, such strategy is labeled `fleet_lock` and takes the following configuration parameters:
+ * `base_url` (string, mandatory, non-empty): the base URL for the FleetLock service.
+
+This strategy can be enabled via a configuration snippet like the following:
+
+```toml
+[updates]
+strategy = "fleet_lock"
+
+[updates.fleet_lock]
+base_url = "http://example.com/fleet_lock/"
+```
+
+The `fleet_lock` strategy is a conservative method which is biased towards avoiding service disruptions, but it requires an external component which is aware of cluster-wide state.
+
+Such an approach is only recommended where nodes are already grouped into an orchestrated cluster, which can thus provide better overall scheduling decisions.
+
+[fleet_lock]: https://github.com/coreos/airlock/pull/1 
+[etcd3]: https://etcd.io/


### PR DESCRIPTION
This adds documentation for updates strategies. In particular this
explains how the lock-based strategy works, and how to configure it.