### PR TITLE
update_agent: introduce some jitter in the refresh loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,6 +2455,7 @@ dependencies = [
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ log = "^0.4.8"
 maplit = "^1.0"
 ordered-float = { version = "^1.0.2", features = ["serde"] }
 prometheus = { version = "^0.7.0", default-features = false }
+rand = "^0.7.0"
 reqwest = "^0.9.20"
 serde = { version = "^1.0.101", features = ["derive"] }
 serde_json = "^1.0.40"


### PR DESCRIPTION
This adds a small random amount of jitter (0% to 10%) to the refresh
loop period. It is meant to prevent multiple clients from converging
into a problematic stable state where all the (distributed) refresh
events are isochronous.

Closes: https://github.com/coreos/zincati/issues/139