### PR TITLE
docs: add configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,28 @@
 # Zincati
 
 [![Build status](https://travis-ci.org/coreos/zincati.svg?branch=master)](https://travis-ci.org/coreos/zincati)
+[![crates.io](https://img.shields.io/crates/v/zincati.svg)](https://crates.io/crates/zincati)
 
-Zincati is the update agent for Fedora CoreOS hosts.
+Zincati is an auto-update agent for Fedora CoreOS hosts.
 
-It works as a client for [Cincinnati] and [rpm-ostree], and it takes care of automatic updating/rebooting machines.
+It works as a client for [Cincinnati] and [rpm-ostree], taking care of automatically updating/rebooting machines.
+
+Features:
+ * Agent for [continuous auto-updates][auto-updates], with support for phased rollouts
+ * [Configuration][configuration] via TOML dropins and overlaid directories
+ * Multiple [update strategies][updates-strategy] for finalization/reboot
+ * Internal [metrics][metrics] exposed over a local endpoint
+ * [Logging][logging] with configurable priority levels
+ * Support for complex update-graphs in Cincinnati format
+ * Support for cluster-wide reboot orchestration, via an external lock-manager
 
 ![cluster reboot graph](./docs/images/metrics.png)
 
 [Cincinnati]: https://github.com/openshift/cincinnati
-[rpm-ostree]: https://github.com/projectatomic/rpm-ostree
+[rpm-ostree]: https://github.com/coreos/rpm-ostree
+
+[auto-updates]: ./docs/usage/auto-updates.md
+[configuration]: ./docs/usage/configuration.md
+[updates-strategy]: ./docs/usage/updates-strategy.md
+[metrics]: ./docs/usage/metrics.md
+[logging]: ./docs/usage/logging.md

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -1,0 +1,40 @@
+# Configuration
+
+Zincati supports runtime customization via configuration fragments (dropins), allowing users and distributions to tweak the agent behavior by writing plain-text files.
+
+Each configuration fragment is a TOML snippet which is read by Zincati and assembled into the final runtime configuration. Only files with a `.toml` extension are considered.
+
+Dropins are sourced from multiple directories, and merged by filename in lexicographic order.
+
+The following configuration paths are scanned by Zincati, in order:
+ * `/usr/lib/zincati/config.d/`: distribution defaults, read-only path owned by the OS.
+ * `/etc/zincati/config.d/`: user customizations, writable path owned by the system administrator.
+ * `/run/zincati/config.d/`: runtime customizations, writable path that is not persisted across reboots.
+
+Configuration directives from files that appear later in sorting order can override prior directives.
+
+If multiple files with the same name exist, only the last-sorting one is read.
+
+Additionally, symbolic links to `/dev/null` can be used to completely override a prior file with the same name.
+
+Configuration dropins are organized in multiple TOML sections, which are described in details in their own documentation pages.
+
+## Example
+
+As an example, distribution defaults may generically enable a feature, but users may need to disable that in specific case.
+
+To that extent, distributions can provide by default the following content at `/usr/lib/zincati/config.d/10-enable-feature.toml`:
+
+```toml
+[feature]
+enabled = true
+```
+
+In order to override that setting, users can write the following to `/etc/zincati/config.d/90-disable-feature.toml`:
+
+```toml
+[feature]
+enabled = false
+```
+
+After sorting all configuration directives by directory and filename priority, the user-provided dropin is considered with the highest priority. Thus, it will override any conflicting directives from other fragments.


### PR DESCRIPTION
This adds documentation explaining how Zincati configuration works.
It shows directories sorting and dropins overrides.