### PR TITLE
strategy/fleet_lock: uniform and instrument errors

### DIFF
--- a/src/cincinnati/client.rs
+++ b/src/cincinnati/client.rs
@@ -72,7 +72,7 @@ impl CincinnatiError {
             CincinnatiError::FailedJSONDecoding(_) => "client_failed_json_decoding".to_string(),
             CincinnatiError::FailedNodeLookup(_) => "client_failed_node_lookup".to_string(),
             CincinnatiError::FailedNodeParsing(_) => "client_failed_node_parsing".to_string(),
-            CincinnatiError::FailedRequest(_) => "client_failed_json_decoding".to_string(),
+            CincinnatiError::FailedRequest(_) => "client_failed_request".to_string(),
         }
     }
 

--- a/src/cincinnati/mod.rs
+++ b/src/cincinnati/mod.rs
@@ -89,7 +89,9 @@ impl Cincinnati {
         log::trace!("checking upstream Cincinnati server for updates");
 
         let update = self.next_update(id, deployments).map_err(|e| {
-            UPDATE_CHECKS_ERRORS.with_label_values(&[&e.error_kind()]).inc();
+            UPDATE_CHECKS_ERRORS
+                .with_label_values(&[&e.error_kind()])
+                .inc();
             log::error!("failed to check Cincinnati for updates: {}", e)
         });
         Box::new(update)


### PR DESCRIPTION
This uniforms all FleetLock-related logic to use a module-specific
error type. The intent is to make sure each failure can be recorded
with machine-friendly and human-friendly identifiers.
For server errors, it tracks the status code too.

It also augments error metrics with the machine-friendly
kind and api endpoint.