### PR TITLE
Release 0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.6-alpha.0"
+version = "0.0.6"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.6"
+version = "0.0.7-alpha.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.6"
+version = "0.0.7-alpha.0"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.6-alpha.0"
+version = "0.0.6"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]


### PR DESCRIPTION
Changes:
 * cincinnati: evaluate dead-end status for booted OS
 * strategy/fleet_lock: uniform and instrument errors
 * cincinnati: uniform and instrument error kinds
 * docs: add configuration documentation
 * fleet_lock: update protocol parameters
 * identity: rename OS version metrics
 * docs: visualize updates finalization
 * docs: explain lock-based updates strategy
 * strategy: add FleetLock cluster-wide reboot coordination
 * rpm_ostree/deploy: do not error on exit code 77
 * update_agent: introduce some jitter in the refresh loop
 * rpm-ostree: do not update to already deployed releases
 * identity: expose OS version metrics
 * docs: explain phased rollouts and client wariness

Tracker: https://github.com/coreos/zincati/milestone/3?closed=1