### PR TITLE
Revert "rpm_ostree/deploy: do not error on exit code 77"

### DIFF
--- a/src/rpm_ostree/cli_deploy.rs
+++ b/src/rpm_ostree/cli_deploy.rs
@@ -38,12 +38,8 @@ fn invoke_cli(release: Release) -> Fallible<Release> {
         .arg(format!("revision={}", release.checksum))
         .output()
         .with_context(|e| format_err!("failed to run rpm-ostree: {}", e))?;
-    let exit_code = cmd.status.code().unwrap_or(-1);
 
-    // This CLI verb has multiple positive exit codes:
-    //  * 0  => "ok, changes applied"
-    //  * 77 => "ok, unchanged"
-    if !(exit_code == 0 || exit_code == 77) {
+    if !cmd.status.success() {
         bail!(
             "rpm-ostree deploy failed:\n{}",
             String::from_utf8_lossy(&cmd.stderr)


### PR DESCRIPTION
This reverts commit f2a5a486021b2e1440b84a7975d89f88446a2787.

The workaround is not anymore necessary after rpm-ostree v2019.6.

Closes: https://github.com/coreos/zincati/issues/143