### PR TITLE
ci: bump minimum supported Rust version to 1.38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.34.2  # minimum supported toolchain
+  - 1.38.0  # minimum supported toolchain
   - stable
   - beta
   - nightly


### PR DESCRIPTION
Bumping to 1.38 in order to cope with dependency updates.