### PR TITLE
Release 0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.7-alpha.0"
+version = "0.0.7"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.7"
+version = "0.0.8-alpha.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.7-alpha.0"
+version = "0.0.7"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.7"
+version = "0.0.8-alpha.0"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]


### PR DESCRIPTION
Changes:
 * updates: block downgrades, expose opt-in config
 * Revert "rpm_ostree/deploy: do not error on exit code 77"
 * ci: bump minimum supported Rust version to 1.38
 * github: add release-checklist template

Tracker: https://github.com/coreos/zincati/milestone/4?closed=1

