### PR TITLE
zincati: use system proxy in HTTP clients

### DIFF
--- a/src/cincinnati/client.rs
+++ b/src/cincinnati/client.rs
@@ -214,7 +214,7 @@ impl ClientBuilder {
     pub fn build(self) -> Fallible<Client> {
         let hclient = match self.hclient {
             Some(client) => client,
-            None => asynchro::ClientBuilder::new().build()?,
+            None => asynchro::ClientBuilder::new().use_sys_proxy().build()?,
         };
         let query_params = match self.query_params {
             Some(params) => params,

--- a/src/fleet_lock/mod.rs
+++ b/src/fleet_lock/mod.rs
@@ -231,7 +231,7 @@ impl ClientBuilder {
     pub fn build(self) -> Fallible<Client> {
         let hclient = match self.hclient {
             Some(client) => client,
-            None => asynchro::ClientBuilder::new().build()?,
+            None => asynchro::ClientBuilder::new().use_sys_proxy().build()?,
         };
 
         let api_base = reqwest::Url::parse(&self.api_base)


### PR DESCRIPTION
This adds support to detect system proxy from environment variables,
using it for all HTTP clients (i.e. cincinnati and fleet_lock).

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/379