### PR TITLE
config: add agent timing knobs

### DIFF
--- a/dist/config.d/10-agent.toml
+++ b/dist/config.d/10-agent.toml
@@ -1,0 +1,5 @@
+# Configure agent timing.
+[agent.timing]
+
+# Pausing interval between updates checks in steady mode, in seconds.
+steady_interval_secs = 300

--- a/src/config/fragments.rs
+++ b/src/config/fragments.rs
@@ -2,10 +2,13 @@
 
 use ordered_float::NotNan;
 use serde::Deserialize;
+use std::num::NonZeroU64;
 
 /// Top-level configuration stanza.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 pub(crate) struct ConfigFragment {
+    /// Agent configuration.
+    pub(crate) agent: Option<AgentFragment>,
     /// Cincinnati client configuration.
     pub(crate) cincinnati: Option<CincinnatiFragment>,
     /// Agent identity.
@@ -14,6 +17,21 @@ pub(crate) struct ConfigFragment {
     pub(crate) updates: Option<UpdateFragment>,
 }
 
+/// Config fragment for agent settings.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub(crate) struct AgentFragment {
+    /// Timing settings for the agent.
+    pub(crate) timing: Option<AgentTiming>,
+}
+
+/// Config fragment for agent timing.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub(crate) struct AgentTiming {
+    /// Pausing interval between updates checks in steady mode, in seconds (default: 300).
+    pub(crate) steady_interval_secs: Option<NonZeroU64>,
+}
+
+// Config fragment for agent identity.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 pub(crate) struct IdentityFragment {
     /// Update group for this agent (default: 'default')
@@ -65,6 +83,11 @@ mod tests {
         let cfg: ConfigFragment = toml::from_slice(&content).unwrap();
 
         let expected = ConfigFragment {
+            agent: Some(AgentFragment {
+                timing: Some(AgentTiming {
+                    steady_interval_secs: Some(NonZeroU64::new(35).unwrap()),
+                }),
+            }),
             cincinnati: Some(CincinnatiFragment {
                 base_url: Some("http://cincinnati.example.com:80/".to_string()),
             }),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,6 +16,7 @@ use crate::identity::Identity;
 use crate::strategy::UpdateStrategy;
 use failure::{Fallible, ResultExt};
 use serde::Serialize;
+use std::num::NonZeroU64;
 use structopt::clap::crate_name;
 
 /// Runtime configuration for the agent.
@@ -27,6 +28,8 @@ pub(crate) struct Settings {
     pub(crate) allow_downgrade: bool,
     /// Whether to enable auto-updates logic.
     pub(crate) enabled: bool,
+    /// Agent timing, steady state refresh period.
+    pub(crate) steady_interval_secs: NonZeroU64,
     /// Cincinnati configuration.
     pub(crate) cincinnati: Cincinnati,
     /// Agent configuration.
@@ -53,6 +56,7 @@ impl Settings {
     fn validate(cfg: inputs::ConfigInput) -> Fallible<Self> {
         let allow_downgrade = cfg.updates.allow_downgrade;
         let enabled = cfg.updates.enabled;
+        let steady_interval_secs = cfg.agent.steady_interval_secs;
         let identity = Identity::with_config(cfg.identity)
             .context("failed to validate agent identity configuration")?;
         let strategy = UpdateStrategy::with_config(cfg.updates, &identity)
@@ -63,6 +67,7 @@ impl Settings {
         Ok(Self {
             allow_downgrade,
             enabled,
+            steady_interval_secs,
             cincinnati,
             identity,
             strategy,

--- a/tests/fixtures/00-config-sample.toml
+++ b/tests/fixtures/00-config-sample.toml
@@ -1,3 +1,6 @@
+[agent.timing]
+steady_interval_secs = 35
+
 [identity]
 group = "workers"
 node_uuid = "27e3ac02af3946af995c9940e18b0cce"


### PR DESCRIPTION
This adds support for a new config section `agent.timing` to configure
timing-related settings on the agent.
It currently has a single knob `steady_interval_secs` to tweak the refresh
period while in steady state.

Closes: https://github.com/coreos/zincati/issues/203