### PR TITLE
ci: add a clippy run to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 rust:
   - 1.38.0  # minimum supported toolchain
+  - 1.41.0  # pinned toolchain for clippy
   - stable
   - beta
   - nightly
@@ -9,6 +10,18 @@ matrix:
   allow_failures:
     - rust: nightly
 
+before_script:
+  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
+      rustup component add clippy;
+    fi'
+
+env:
+  global:
+    - CLIPPY_RUST_VERSION=1.41.0
+
 script:
   - cargo test
   - cargo test --features failpoints
+  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
+      cargo clippy -- -D warnings;
+    fi'

--- a/src/cincinnati/client.rs
+++ b/src/cincinnati/client.rs
@@ -127,7 +127,7 @@ impl Client {
         let result = future::result(req)
             .and_then(|req| req.send().from_err())
             .map_err(move |e| CincinnatiError::FailedRequest(e.to_string()))
-            .and_then(|resp| Self::map_response(resp));
+            .and_then(Self::map_response);
         Box::new(result)
     }
 

--- a/src/fleet_lock/mod.rs
+++ b/src/fleet_lock/mod.rs
@@ -113,7 +113,7 @@ impl Client {
                 req.send()
                     .map_err(|e| FleetLockError::FailedRequest(e.to_string()))
             })
-            .and_then(|resp| Self::map_response(resp))
+            .and_then(Self::map_response)
     }
 
     /// Try to unlock a semaphore slot on the remote manager.
@@ -130,7 +130,7 @@ impl Client {
                 req.send()
                     .map_err(|e| FleetLockError::FailedRequest(e.to_string()))
             })
-            .and_then(|resp| Self::map_response(resp))
+            .and_then(Self::map_response)
     }
 
     /// Return a request builder for the target URL, with proper parameters set.


### PR DESCRIPTION
This fixes all existing warnings and adds a `clippy` job to travis.