### PR TITLE
cargo: fix release metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,8 @@ lto = true
 
 [package.metadata.release]
 sign-commit = true
-upload-doc = false
 disable-publish = true
 disable-push = true
 pre-release-commit-message = "cargo: zincati release {{version}}"
-pro-release-commit-message = "cargo: development version bump"
+post-release-commit-message = "cargo: development version bump"
 tag-message = "zincati {{version}}"


### PR DESCRIPTION
This fixes manifest metadata for latest `cargo-release`.