### PR TITLE
Release 0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.8"
+version = "0.0.9-alpha.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.8-alpha.0"
+version = "0.0.8"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.8-alpha.0"
+version = "0.0.8"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.8"
+version = "0.0.9-alpha.0"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]


### PR DESCRIPTION
Changes:
 * cargo: fix release metadata
 * config: add agent timing knobs
 * ci: add a clippy run to travis
 * zincati: use system proxy in HTTP clients
 * update_agent: make intervals state specific
 * docs: update metrics example
 * docs: minor fixes to release checklist

Tracker: https://github.com/coreos/zincati/milestone/5