### PR TITLE
zincati: add completion timeout to HTTP requests

### DIFF
--- a/src/cincinnati/client.rs
+++ b/src/cincinnati/client.rs
@@ -15,6 +15,10 @@ use reqwest::r#async as asynchro;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::time::Duration;
+
+/// Default timeout for HTTP requests completion (30 minutes).
+const DEFAULT_HTTP_COMPLETION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
 /// Cincinnati graph API path endpoint (v1).
 static V1_GRAPH_PATH: &str = "v1/graph";
@@ -214,7 +218,10 @@ impl ClientBuilder {
     pub fn build(self) -> Fallible<Client> {
         let hclient = match self.hclient {
             Some(client) => client,
-            None => asynchro::ClientBuilder::new().use_sys_proxy().build()?,
+            None => asynchro::ClientBuilder::new()
+                .use_sys_proxy()
+                .timeout(DEFAULT_HTTP_COMPLETION_TIMEOUT)
+                .build()?,
         };
         let query_params = match self.query_params {
             Some(params) => params,

--- a/src/fleet_lock/mod.rs
+++ b/src/fleet_lock/mod.rs
@@ -12,9 +12,13 @@ use futures::prelude::*;
 use reqwest::r#async as asynchro;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 #[cfg(test)]
 mod mock_tests;
+
+/// Default timeout for HTTP requests completion (30 minutes).
+const DEFAULT_HTTP_COMPLETION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
 /// FleetLock pre-reboot API path endpoint (v1).
 static V1_PRE_REBOOT: &str = "v1/pre-reboot";
@@ -231,7 +235,10 @@ impl ClientBuilder {
     pub fn build(self) -> Fallible<Client> {
         let hclient = match self.hclient {
             Some(client) => client,
-            None => asynchro::ClientBuilder::new().use_sys_proxy().build()?,
+            None => asynchro::ClientBuilder::new()
+                .use_sys_proxy()
+                .timeout(DEFAULT_HTTP_COMPLETION_TIMEOUT)
+                .build()?,
         };
 
         let api_base = reqwest::Url::parse(&self.api_base)


### PR DESCRIPTION
This adds a total completion timeout of 30 minutes to all HTTP
requests for the Cincinnati and FleetLock clients.