### PR TITLE
update-agent: rework steady/polling state

### DIFF
--- a/src/update_agent/actor.rs
+++ b/src/update_agent/actor.rs
@@ -61,20 +61,21 @@ impl Handler<RefreshTick> for UpdateAgent {
         let prev_state = self.state.clone();
 
         let state_action = match &self.state {
-            UpdateAgentState::StartState => self.initialize(),
-            UpdateAgentState::Initialized => self.try_steady(),
-            UpdateAgentState::Steady => self.try_check_updates(),
+            UpdateAgentState::StartState => self.tick_initialize(),
+            UpdateAgentState::Initialized => self.tick_report_steady(),
+            UpdateAgentState::ReportedSteady => self.tick_check_updates(),
+            UpdateAgentState::NoNewUpdate => self.tick_check_updates(),
             UpdateAgentState::UpdateAvailable(release) => {
                 let update = release.clone();
-                self.try_stage_update(update)
+                self.tick_stage_update(update)
             }
             UpdateAgentState::UpdateStaged(release) => {
                 let update = release.clone();
-                self.try_finalize_update(update)
+                self.tick_finalize_update(update)
             }
             UpdateAgentState::UpdateFinalized(release) => {
                 let update = release.clone();
-                self.end(update)
+                self.tick_end(update)
             }
             UpdateAgentState::EndState => self.nop(),
         };
@@ -123,7 +124,9 @@ impl UpdateAgent {
         let default_delay = Duration::from_secs(super::DEFAULT_REFRESH_PERIOD_SECS);
 
         match self.state {
-            UpdateAgentState::Steady => self.steady_interval,
+            UpdateAgentState::ReportedSteady | UpdateAgentState::NoNewUpdate => {
+                self.steady_interval
+            }
             _ => default_delay,
         }
     }
@@ -142,7 +145,7 @@ impl UpdateAgent {
     }
 
     /// Initialize the update agent.
-    fn initialize(&mut self) -> ResponseActFuture<Self, Result<(), ()>> {
+    fn tick_initialize(&mut self) -> ResponseActFuture<Self, Result<(), ()>> {
         trace!("update agent in start state");
 
         let initialization = self.nop().map(|_r, actor, _ctx| {
@@ -159,8 +162,8 @@ impl UpdateAgent {
         Box::new(initialization)
     }
 
-    /// Try to reach steady state.
-    fn try_steady(&mut self) -> ResponseActFuture<Self, Result<(), ()>> {
+    /// Try to report steady state.
+    fn tick_report_steady(&mut self) -> ResponseActFuture<Self, Result<(), ()>> {
         trace!("trying to report steady state");
 
         let report_steady = self.strategy.report_steady(&self.identity);
@@ -168,7 +171,7 @@ impl UpdateAgent {
             actix::fut::wrap_future::<_, Self>(report_steady).map(|is_steady, actor, _ctx| {
                 if is_steady {
                     log::debug!("reached steady state, periodically polling for updates");
-                    actor.state.steady();
+                    actor.state.reported_steady();
                 }
                 Ok(())
             });
@@ -177,7 +180,7 @@ impl UpdateAgent {
     }
 
     /// Try to check for updates.
-    fn try_check_updates(&mut self) -> ResponseActFuture<Self, Result<(), ()>> {
+    fn tick_check_updates(&mut self) -> ResponseActFuture<Self, Result<(), ()>> {
         trace!("trying to check for updates");
 
         let can_check = self.strategy.can_check_and_fetch(&self.identity);
@@ -197,7 +200,10 @@ impl UpdateAgent {
                 release.into_actor(actor)
             })
             .map(|res, actor, _ctx| {
-                actor.state.update_available(res);
+                match res {
+                    Some(release) => actor.state.update_available(release),
+                    None => actor.state.no_new_update(),
+                };
                 Ok(())
             });
 
@@ -205,7 +211,7 @@ impl UpdateAgent {
     }
 
     /// Try to stage an update.
-    fn try_stage_update(&mut self, release: Release) -> ResponseActFuture<Self, Result<(), ()>> {
+    fn tick_stage_update(&mut self, release: Release) -> ResponseActFuture<Self, Result<(), ()>> {
         trace!("trying to stage an update");
 
         let can_fetch = self.strategy.can_check_and_fetch(&self.identity);
@@ -217,7 +223,10 @@ impl UpdateAgent {
     }
 
     /// Try to finalize an update.
-    fn try_finalize_update(&mut self, release: Release) -> ResponseActFuture<Self, Result<(), ()>> {
+    fn tick_finalize_update(
+        &mut self,
+        release: Release,
+    ) -> ResponseActFuture<Self, Result<(), ()>> {
         trace!("trying to finalize an update");
 
         let can_finalize = self.strategy.can_finalize(&self.identity);
@@ -229,7 +238,7 @@ impl UpdateAgent {
     }
 
     /// Actor job is done.
-    fn end(&mut self, release: Release) -> ResponseActFuture<Self, Result<(), ()>> {
+    fn tick_end(&mut self, release: Release) -> ResponseActFuture<Self, Result<(), ()>> {
         log::info!("update applied, waiting for reboot: {}", release.version);
         let state_change = self.nop().map(|_r, actor, _ctx| {
             actor.state.end();

--- a/src/update_agent/actor.rs
+++ b/src/update_agent/actor.rs
@@ -19,6 +19,10 @@ lazy_static::lazy_static! {
         "zincati_update_agent_last_refresh_timestamp",
         "UTC timestamp of update-agent last refresh tick."
     )).unwrap();
+    static ref UPDATES_ENABLED: IntGauge = register_int_gauge!(opts!(
+        "zincati_update_agent_updates_enabled",
+        "Whether auto-updates logic is enabled."
+    )).unwrap();
 }
 
 impl Actor for UpdateAgent {
@@ -26,6 +30,9 @@ impl Actor for UpdateAgent {
 
     fn started(&mut self, ctx: &mut Self::Context) {
         trace!("update agent started");
+
+        // TODO(lucab): consider adding more metrics here (e.g. steady interval).
+        UPDATES_ENABLED.set(i64::from(self.enabled));
 
         if self.allow_downgrade {
             ALLOW_DOWNGRADE.set(1);
@@ -97,7 +104,7 @@ impl Handler<RefreshTick> for UpdateAgent {
 }
 
 impl UpdateAgent {
-    /// Schedule an immediate refresh the state machine.
+    /// Schedule an immediate refresh of the state machine.
     pub fn tick_now(ctx: &mut Context<Self>) {
         ctx.notify(RefreshTick {})
     }

--- a/src/update_agent/mod.rs
+++ b/src/update_agent/mod.rs
@@ -31,8 +31,10 @@ enum UpdateAgentState {
     StartState,
     /// Agent initialized.
     Initialized,
-    /// Agent ready to check for updates.
-    Steady,
+    /// Node steady, agent allowed to check for updates.
+    ReportedSteady,
+    /// No further updates available yet.
+    NoNewUpdate,
     /// Update available from Cincinnati.
     UpdateAvailable(Release),
     /// Update staged by rpm-ostree.
@@ -52,22 +54,6 @@ impl Default for UpdateAgentState {
 }
 
 impl UpdateAgentState {
-    /// Return the discriminant for current state
-    fn discriminant(&self) -> u8 {
-        // TODO(lucab): update when arbitrary-discriminant is stabilized:
-        // https://github.com/rust-lang/rust/issues/60553
-
-        match self {
-            UpdateAgentState::StartState => 0,
-            UpdateAgentState::Initialized => 1,
-            UpdateAgentState::Steady => 2,
-            UpdateAgentState::UpdateAvailable(_) => 3,
-            UpdateAgentState::UpdateStaged(_) => 4,
-            UpdateAgentState::UpdateFinalized(_) => 5,
-            UpdateAgentState::EndState => 6,
-        }
-    }
-
     /// Progress the machine to a new state.
     fn transition_to(&mut self, state: Self) {
         LATEST_STATE_CHANGE.set(chrono::Utc::now().timestamp());
@@ -77,43 +63,79 @@ impl UpdateAgentState {
 
     /// Transition to the Initialized state.
     fn initialized(&mut self) {
+        let target = UpdateAgentState::Initialized;
         // Allowed starting states.
-        assert!(self.discriminant() == 0);
+        assert!(
+            *self == UpdateAgentState::StartState,
+            "transition not allowed: {:?} to {:?}",
+            self,
+            target,
+        );
 
-        self.transition_to(UpdateAgentState::Initialized);
+        self.transition_to(target);
     }
 
-    /// Transition to the Steady state.
-    fn steady(&mut self) {
+    /// Transition to the ReportedSteady state.
+    fn reported_steady(&mut self) {
+        let target = UpdateAgentState::ReportedSteady;
         // Allowed starting states.
-        assert!(*self == UpdateAgentState::Initialized);
+        assert!(
+            *self == UpdateAgentState::Initialized,
+            "transition not allowed: {:?} to {:?}",
+            self,
+            target,
+        );
 
-        self.transition_to(UpdateAgentState::Steady);
+        self.transition_to(target);
+    }
+
+    /// Transition to the NoNewUpdate state.
+    fn no_new_update(&mut self) {
+        let target = UpdateAgentState::NoNewUpdate;
+        // Allowed starting states.
+        assert!(
+            *self == UpdateAgentState::ReportedSteady || *self == UpdateAgentState::NoNewUpdate,
+            "transition not allowed: {:?} to {:?}",
+            self,
+            target
+        );
+
+        self.transition_to(UpdateAgentState::NoNewUpdate);
     }
 
     /// Transition to the UpdateAvailable state.
-    fn update_available(&mut self, update: Option<Release>) {
+    fn update_available(&mut self, update: Release) {
+        let target = UpdateAgentState::UpdateAvailable(update);
         // Allowed starting states.
-        assert!(*self == UpdateAgentState::Steady);
+        assert!(
+            *self == UpdateAgentState::ReportedSteady || *self == UpdateAgentState::NoNewUpdate,
+            "transition not allowed: {:?} to {:?}",
+            self,
+            target
+        );
 
-        if let Some(release) = update {
-            self.transition_to(UpdateAgentState::UpdateAvailable(release));
-        }
+        self.transition_to(target);
     }
 
     /// Transition to the UpdateStaged state.
     fn update_staged(&mut self, update: Release) {
-        self.transition_to(UpdateAgentState::UpdateStaged(update));
+        let target = UpdateAgentState::UpdateStaged(update);
+
+        self.transition_to(target);
     }
 
     /// Transition to the UpdateFinalized state.
     fn update_finalized(&mut self, update: Release) {
-        self.transition_to(UpdateAgentState::UpdateFinalized(update));
+        let target = UpdateAgentState::UpdateFinalized(update);
+
+        self.transition_to(target);
     }
 
     /// Transition to the End state.
     fn end(&mut self) {
-        self.transition_to(UpdateAgentState::EndState);
+        let target = UpdateAgentState::EndState;
+
+        self.transition_to(target);
     }
 }
 
@@ -181,18 +203,21 @@ mod tests {
         machine.initialized();
         assert_eq!(machine, UpdateAgentState::Initialized);
 
-        machine.steady();
-        assert_eq!(machine, UpdateAgentState::Steady);
+        machine.reported_steady();
+        assert_eq!(machine, UpdateAgentState::ReportedSteady);
 
-        machine.update_available(None);
-        assert_eq!(machine, UpdateAgentState::Steady);
+        machine.no_new_update();
+        assert_eq!(machine, UpdateAgentState::NoNewUpdate);
+
+        machine.no_new_update();
+        assert_eq!(machine, UpdateAgentState::NoNewUpdate);
 
         let update = Release {
             version: "v1".to_string(),
             checksum: "ostree-checksum".to_string(),
             age_index: None,
         };
-        machine.update_available(Some(update.clone()));
+        machine.update_available(update.clone());
         assert_eq!(machine, UpdateAgentState::UpdateAvailable(update.clone()));
 
         machine.update_staged(update.clone());

--- a/src/update_agent/mod.rs
+++ b/src/update_agent/mod.rs
@@ -22,10 +22,6 @@ lazy_static::lazy_static! {
         "zincati_update_agent_latest_state_change_timestamp",
         "UTC timestamp of update-agent last state change."
     )).unwrap();
-    static ref UPDATES_ENABLED: IntGauge = register_int_gauge!(opts!(
-        "zincati_update_agent_updates_enabled",
-        "Whether auto-updates logic is enabled."
-    )).unwrap();
 }
 
 /// State machine for the agent.
@@ -162,10 +158,6 @@ impl UpdateAgent {
             strategy: cfg.strategy,
             state_changed: chrono::Utc::now(),
         };
-
-        // TODO(lucab): consider adding more metrics here
-        //  (e.g. steady interval, downgrade allowed, etc.)
-        UPDATES_ENABLED.set(i64::from(cfg.enabled));
 
         Ok(agent)
     }


### PR DESCRIPTION
This splits the "reported steady" and "checked, but no updates
available" states, making it easier to track and report upgrade
progress.

Closes: https://github.com/coreos/zincati/issues/229