### PR TITLE
metrics: stabilize metrics endpoint

### DIFF
--- a/dist/tmpfiles.d/zincati.conf
+++ b/dist/tmpfiles.d/zincati.conf
@@ -7,6 +7,8 @@ d     /run/zincati/config.d  0775 zincati zincati  -   -
 # Runtime state, unstable/private implementation details
 d     /run/zincati/private   0770 zincati zincati  -   -
 
-# TODO(lucab): stabilize metrics and make them public here
 # Runtime public interfaces
-#d     /run/zincati/public    0775 zincati zincati  -   -
+d     /run/zincati/public    0775 zincati zincati  -   -
+
+# Legacy symlink to metrics socket
+L+    /run/zincati/private/metrics.promsock  - - - - ../public/metrics.promsock

--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -1,7 +1,5 @@
 # Metrics
 
-**NOTE**: metrics endpoint is not yet a stable public interface, and it is expected to change at some point in the future.
-
 Zincati tracks and exposes some of its internal metrics, in order to ease monitoring tasks across a large fleet of nodes.
 
 Metrics are collected and exported according to [Prometheus] [textual format](prom-text), over a local endpoint.
@@ -11,12 +9,12 @@ Metrics are collected and exported according to [Prometheus] [textual format](pr
 
 ## Gathering metrics
 
-To gather metrics from a locally running Zincati instance, it is sufficient to connect and read from the Unix-domain socket located at `/run/zincati/private/metrics.promsock`.
+To gather metrics from a locally running Zincati instance, it is sufficient to connect and read from the Unix-domain socket located at `/run/zincati/public/metrics.promsock`.
 
 For example, manual inspection can be performed via `ncat`:
 
 ```
-$ sudo socat - UNIX-CONNECT:/run/zincati/private/metrics.promsock
+$ sudo socat - UNIX-CONNECT:/run/zincati/public/metrics.promsock
 
 # HELP zincati_update_agent_last_refresh_timestamp UTC timestamp of update-agent last refresh tick.
 # TYPE zincati_update_agent_last_refresh_timestamp gauge
@@ -27,4 +25,10 @@ zincati_update_agent_latest_state_change_timestamp 1563360122
 # HELP zincati_update_agent_updates_enabled Whether auto-updates logic is enabled.
 # TYPE zincati_update_agent_updates_enabled gauge
 zincati_update_agent_updates_enabled 1
+[...]
 ```
+
+Additionally, the local Unix-domain socket can be proxied to HTTP and exposed to Prometheus.
+For an example of such setup, check the [local\_exporter] repository.
+
+[local_exporter]: https://github.com/lucab/local_exporter

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -6,7 +6,7 @@ use std::os::unix::net as std_net;
 use tokio::net as tokio_net;
 
 /// Unix socket path.
-static SOCKET_PATH: &str = "/run/zincati/private/metrics.promsock";
+static SOCKET_PATH: &str = "/run/zincati/public/metrics.promsock";
 
 /// Metrics exposition service.
 pub struct MetricsService {


### PR DESCRIPTION
This stabilize the metrics endpoint under its new public path,
`/run/zincati/public/metrics.promsock`.
Previous private path is kept as a symlink for compatibility.

Closes: https://github.com/coreos/zincati/issues/74