### PR TITLE
Release 0.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.9"
+version = "0.0.10-alpha.0"
 dependencies = [
  "actix",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.9-alpha.0"
+version = "0.0.9"
 dependencies = [
  "actix",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.9-alpha.0"
+version = "0.0.9"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.9"
+version = "0.0.10-alpha.0"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]


### PR DESCRIPTION
Changes:
 * zincati: rework to use std::future
 * zincati: add completion timeout to HTTP requests
 * metrics: stabilize metrics endpoint
 * update-agent: rework steady/polling state
 * docs: add state-machine diagram
 * cargo: relax dependencies micro versions
 * cargo: update all dependencies

Tracker: https://github.com/coreos/zincati/milestone/6