### PR TITLE
systemd: Activative via zincati.timer, not by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all:
 install:
 	install -D -t ${DESTDIR}/usr/libexec target/${PROFILE}/zincati
 	install -D -m 644 -t ${DESTDIR}/usr/lib/zincati/config.d dist/config.d/*.toml
-	install -D -m 644 -t ${DESTDIR}/usr/lib/systemd/system dist/systemd/system/*.service
+	install -D -m 644 -t ${DESTDIR}/usr/lib/systemd/system dist/systemd/system/*.{service,timer}
 	install -D -m 644 -t ${DESTDIR}/usr/lib/sysusers.d dist/sysusers.d/*.conf
 	install -D -m 644 -t ${DESTDIR}/usr/lib/tmpfiles.d dist/tmpfiles.d/*.conf
 	install -D -m 644 -t ${DESTDIR}/usr/share/polkit-1/rules.d dist/polkit-1/rules.d/*.rules

--- a/dist/systemd/system/zincati.service
+++ b/dist/systemd/system/zincati.service
@@ -16,6 +16,3 @@ Environment=ZINCATI_VERBOSITY="-v"
 ExecStart=/usr/libexec/zincati agent ${ZINCATI_VERBOSITY}
 Restart=on-failure
 RestartSec=10s
-
-[Install]
-WantedBy=multi-user.target

--- a/dist/systemd/system/zincati.timer
+++ b/dist/systemd/system/zincati.timer
@@ -1,0 +1,8 @@
+[Timer]
+# Spreading things across 30 minutes should help
+# to avoid thundering herds by default.
+OnBootSec=1h
+AccuracySec=30m
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Fedora CoreOS bootup is pretty slow relative to other
distributions out there.  I use `cosa run` a *lot*.  Part
of starting faster is simply doing less.

Starting rpm-ostree today unfortunately is a bit heavyweight.
And zincati is its own service with a binary of nontrivial size.

Since auto-updates are going to be slowly rolled out anyways on
the server side, let's hook zincati startup to an asynchronous
timer run after normal bootup.

In particular, starting zincati/rpm-ostree is no longer *before*
the login prompt with `cosa run`.

But by using a timer with an accuracy slack, we should also
avoid "thundering herd" problems when a lot of machines
boot up at once after e.g. a power failure and go to check
in with the server.