### PR TITLE
config: update FCOS Cincinnati endpoint (prod)

### DIFF
--- a/dist/config.d/50-fedora-coreos-cincinnati.toml
+++ b/dist/config.d/50-fedora-coreos-cincinnati.toml
@@ -1,3 +1,3 @@
-# Fedora CoreOS Cincinnati backend (staging service)
+# Fedora CoreOS Cincinnati backend
 [cincinnati]
-base_url= "https://updates.coreos.stg.fedoraproject.org"
+base_url= "https://updates.coreos.fedoraproject.org"


### PR DESCRIPTION
This updates the default FCOS Cincinnati endpoint, switching from
staging infrastructure to production one.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/347