### PR TITLE
Release 0.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.11-alpha.0"
+version = "0.0.11"
 dependencies = [
  "actix",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.11"
+version = "0.0.12-alpha.0"
 dependencies = [
  "actix",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.11-alpha.0"
+version = "0.0.11"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.11"
+version = "0.0.12-alpha.0"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]


### PR DESCRIPTION
Changes:
 * update-agent: react to persistent deploy failure
 * docs/devel: document required metadata for introspection
 * strategy: add logic for weekly maintenance windows

Tracker: https://github.com/coreos/zincati/milestone/8