### PR TITLE
rpm-ostree/status: detect and handle staged deployments

### DIFF
--- a/src/rpm_ostree/actor.rs
+++ b/src/rpm_ostree/actor.rs
@@ -65,7 +65,10 @@ impl Handler<FinalizeDeployment> for RpmOstreeClient {
 
 /// Request: query local deployments.
 #[derive(Debug, Clone)]
-pub struct QueryLocalDeployments {}
+pub struct QueryLocalDeployments {
+    /// Whether to include staged (i.e. not finalized) deployments in query result.
+    pub(crate) omit_staged: bool,
+}
 
 impl Message for QueryLocalDeployments {
     type Result = Fallible<BTreeSet<Release>>;
@@ -74,8 +77,12 @@ impl Message for QueryLocalDeployments {
 impl Handler<QueryLocalDeployments> for RpmOstreeClient {
     type Result = Fallible<BTreeSet<Release>>;
 
-    fn handle(&mut self, _msg: QueryLocalDeployments, _ctx: &mut Self::Context) -> Self::Result {
+    fn handle(
+        &mut self,
+        query_msg: QueryLocalDeployments,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
         trace!("request to list local deployments");
-        super::cli_status::local_deployments()
+        super::cli_status::local_deployments(query_msg.omit_staged)
     }
 }

--- a/src/update_agent/actor.rs
+++ b/src/update_agent/actor.rs
@@ -299,7 +299,10 @@ impl UpdateAgent {
         }
     }
 
-    /// List local deployments.
+    /// List persistent (i.e. finalized) local deployments.
+    ///
+    /// This ignores deployments that have been only staged but not finalized in the
+    /// past, as they are acceptable as future update target.
     fn local_deployments(
         &mut self,
         can_fetch: bool,
@@ -308,7 +311,7 @@ impl UpdateAgent {
             return Box::new(actix::fut::ok((can_fetch, BTreeSet::new())));
         }
 
-        let msg = rpm_ostree::QueryLocalDeployments {};
+        let msg = rpm_ostree::QueryLocalDeployments { omit_staged: true };
         let depls = self
             .rpm_ostree_actor
             .send(msg)

--- a/tests/fixtures/rpm-ostree-staged.json
+++ b/tests/fixtures/rpm-ostree-staged.json
@@ -1,0 +1,150 @@
+{
+  "deployments" : [
+    {
+      "unlocked" : "none",
+      "requested-local-packages" : [
+      ],
+      "base-commit-meta" : {
+        "coreos-assembler.config-gitrev" : "e0a85592cf67d075e510f1ed29a40957aeca3617",
+        "coreos-assembler.config-dirty" : "false",
+        "rpmostree.inputhash" : "77dbde3d9502f2f87757d2b68b93b52efa2c65fb7b1fc317e0ffc50b483a3a52",
+        "coreos-assembler.basearch" : "x86_64",
+        "fedora-coreos.stream" : "stable",
+        "version" : "31.20200517.3.0",
+        "rpmostree.initramfs-args" : [
+          "--add=ignition",
+          "--no-hostonly",
+          "--omit=nfs",
+          "--omit=lvm",
+          "--omit=multipath",
+          "--omit=iscsi"
+        ],
+        "rpmostree.rpmmd-repos" : [
+          {
+            "id" : "fedora-coreos-pool",
+            "timestamp" : 1590960454
+          }
+        ]
+      },
+      "base-removals" : [
+      ],
+      "gpg-enabled" : true,
+      "origin" : "fedora:fedora/x86_64/coreos/stable",
+      "osname" : "fedora-coreos",
+      "pinned" : false,
+      "requested-base-local-replacements" : [
+      ],
+      "checksum" : "967b7b8d624e6d10ff51c2e81ef198fae966c567ac2e9b479771c693d0987949",
+      "booted" : false,
+      "regenerate-initramfs" : false,
+      "id" : "fedora-coreos-967b7b8d624e6d10ff51c2e81ef198fae966c567ac2e9b479771c693d0987949.0",
+      "version" : "31.20200517.3.0",
+      "requested-packages" : [
+      ],
+      "requested-base-removals" : [
+      ],
+      "signatures" : [
+        [
+          true,
+          false,
+          false,
+          false,
+          false,
+          "7D22D5867F2A4236474BF7B850CB390B3C3359C4",
+          1591031924,
+          0,
+          "RSA",
+          "SHA256",
+          "Fedora",
+          "fedora-31-primary@fedoraproject.org",
+          "7D22D5867F2A4236474BF7B850CB390B3C3359C4",
+          1866067200,
+          1866067200
+        ]
+      ],
+      "serial" : 0,
+      "timestamp" : 1591031729,
+      "staged" : true,
+      "finalization-locked" : true,
+      "packages" : [
+      ],
+      "base-local-replacements" : [
+      ]
+    },
+    {
+      "unlocked" : "none",
+      "pending-base-version" : "31.20200517.3.0",
+      "base-commit-meta" : {
+        "coreos-assembler.config-gitrev" : "a333cfdcf02c622883e08f99d08745430c5e93eb",
+        "coreos-assembler.config-dirty" : "false",
+        "rpmostree.inputhash" : "3efbafd926cbd112d0049aaebf5c025812229ab23fc84bd6800d959ac919b03a",
+        "coreos-assembler.basearch" : "x86_64",
+        "fedora-coreos.stream" : "stable",
+        "version" : "31.20200505.3.0",
+        "rpmostree.initramfs-args" : [
+          "--add=ignition",
+          "--no-hostonly",
+          "--omit=nfs",
+          "--omit=lvm",
+          "--omit=multipath",
+          "--omit=iscsi"
+        ],
+        "rpmostree.rpmmd-repos" : [
+          {
+            "id" : "fedora-coreos-pool",
+            "timestamp" : 1589664881
+          }
+        ]
+      },
+      "requested-local-packages" : [
+      ],
+      "base-removals" : [
+      ],
+      "gpg-enabled" : true,
+      "origin" : "fedora:fedora/x86_64/coreos/stable",
+      "osname" : "fedora-coreos",
+      "pinned" : false,
+      "requested-base-local-replacements" : [
+      ],
+      "checksum" : "01f074cc6cd88d8d2b43f821da692f2367c101eb4377802cb35092bde0ef02f7",
+      "regenerate-initramfs" : false,
+      "id" : "fedora-coreos-01f074cc6cd88d8d2b43f821da692f2367c101eb4377802cb35092bde0ef02f7.0",
+      "version" : "31.20200505.3.0",
+      "requested-packages" : [
+      ],
+      "requested-base-removals" : [
+      ],
+      "signatures" : [
+        [
+          true,
+          false,
+          false,
+          false,
+          false,
+          "7D22D5867F2A4236474BF7B850CB390B3C3359C4",
+          1589895778,
+          0,
+          "RSA",
+          "SHA256",
+          "Fedora",
+          "fedora-31-primary@fedoraproject.org",
+          "7D22D5867F2A4236474BF7B850CB390B3C3359C4",
+          1866067200,
+          1866067200
+        ]
+      ],
+      "serial" : 0,
+      "timestamp" : 1589895586,
+      "base-local-replacements" : [
+      ],
+      "packages" : [
+      ],
+      "pending-base-timestamp" : 1591031729,
+      "booted" : true,
+      "pending-base-checksum" : "967b7b8d624e6d10ff51c2e81ef198fae966c567ac2e9b479771c693d0987949"
+    }
+  ],
+  "transaction" : null,
+  "cached-update" : null
+}
+


### PR DESCRIPTION
This augments rpm-ostree status querying logic in order to detected
staged-but-not-finalized deployments, i.e. those that haven't really
been persisted locally in the past.
Zincati uses this new logic in order to distinguish between previous
deployments (e.g. in case of rollbacks) and temporarily staged ones
(e.g. in case of manual interventions or half-applied updates). The
latter ones can be considered as future update targets, while the
former ones should not.

Fixes: https://github.com/coreos/zincati/issues/293