### PR TITLE
contrib: add monitoring mixins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 **/*.rs.bk
+vendor
+jsonnetfile.lock.json
+dashboard_out

--- a/contrib/monitoring-mixins/README.md
+++ b/contrib/monitoring-mixins/README.md
@@ -1,0 +1,24 @@
+# Requirements
+
+In order to customize and generate monitoring artifacts, the following tools are required:
+
+ * `jb` available at <https://github.com/jsonnet-bundler/jsonnet-bundler>.
+ * `jsonnet` available at <https://github.com/google/jsonnet>.
+ * `mixtool` available at <https://github.com/monitoring-mixins/mixtool>.
+
+For more information, see <https://monitoring.mixins.dev/>.
+
+# Artifacts generation
+
+Monitoring artifacts can be generated from mixins in a few steps:
+
+```sh
+# Clean stale artifacts.
+rm -rf vendor/ generated/ jsonnetfile.lock.json
+
+# Fetch jsonnet libraries.
+jb install
+
+# Generate Grafana dashboards.
+mixtool generate dashboards -d generated/dashboards/ mixin.libsonnet
+```

--- a/contrib/monitoring-mixins/dashboards/dashboards.libsonnet
+++ b/contrib/monitoring-mixins/dashboards/dashboards.libsonnet
@@ -1,0 +1,117 @@
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local row = grafana.row;
+local prometheus = grafana.prometheus;
+local graphPanel = grafana.graphPanel;
+
+{
+  grafanaDashboards+:: {
+    'dashboard.json':
+      dashboard.new(
+        'Fedora CoreOS updates (Zincati)',
+        time_from='now-7d',
+      ).addTemplate(
+        {
+          current: {
+            text: 'Prometheus',
+            value: 'Prometheus',
+          },
+          hide: 0,
+          label: null,
+          name: 'datasource',
+          options: [],
+          query: 'prometheus',
+          refresh: 1,
+          regex: '',
+          type: 'datasource',
+        },
+      )
+      .addRow(
+        row.new(
+          title='Agent identity',
+        )
+        .addPanel(
+          graphPanel.new(
+            'OS versions',
+            datasource='$datasource',
+            decimalsY1=0,
+            format='short',
+            legend_alignAsTable=true,
+            legend_current=true,
+            legend_show=true,
+            legend_values=true,
+            min=0,
+            span=6,
+            stack=true,
+          )
+          .addTarget(prometheus.target(
+            'sum by(os_version) (zincati_identity_os_info)',
+            legendFormat='{{os_version}}'
+          ))
+        )
+        .addPanel(
+          graphPanel.new(
+            'Static rollout wariness',
+            datasource='$datasource',
+            format='short',
+            legend_show=true,
+            min=0,
+            span=6,
+          )
+          .addTarget(prometheus.target(
+            'zincati_identity_rollout_wariness != 0',
+            legendFormat='{{instance}}'
+          ))
+        )
+      )
+      .addRow(
+        row.new(
+          title='Agent details',
+        )
+        .addPanel(
+          graphPanel.new(
+            'Agent refresh period (p99)',
+            datasource='$datasource',
+            formatY1='s',
+            span=6,
+            min=0,
+          )
+          .addTarget(prometheus.target(
+            'quantile_over_time(0.99, (time() - zincati_update_agent_last_refresh_timestamp)[15m:])',
+            legendFormat='{{instance}}'
+          ))
+        )
+        .addPanel(
+          graphPanel.new(
+            'Cincinnati client error-rate',
+            datasource='$datasource',
+            span=6,
+            min=0,
+          )
+          .addTarget(prometheus.target(
+            'sum by (kind) (rate(zincati_cincinnati_update_checks_errors_total[5m]))',
+            legendFormat='kind: {{kind}}'
+          ))
+        )
+        .addPanel(
+          graphPanel.new(
+            'Deadends detected',
+            datasource='$datasource',
+            decimalsY1=0,
+            format='short',
+            legend_alignAsTable=true,
+            legend_current=true,
+            legend_show=true,
+            legend_values=true,
+            min=0,
+            span=6,
+            stack=true,
+          )
+          .addTarget(prometheus.target(
+            'sum by (os_version) ((zincati_cincinnati_booted_release_is_deadend) + on (instance) group_left(os_version) (0*zincati_identity_os_info))',
+            legendFormat='{{os_version}}'
+          ))
+        )
+      ),
+  },
+}

--- a/contrib/monitoring-mixins/jsonnetfile.json
+++ b/contrib/monitoring-mixins/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "8fb95bd89990e493a8534205ee636bfcb8db67bd"
+    }
+  ],
+  "legacyImports": false
+}

--- a/contrib/monitoring-mixins/mixin.libsonnet
+++ b/contrib/monitoring-mixins/mixin.libsonnet
@@ -1,0 +1,1 @@
+(import 'dashboards/dashboards.libsonnet')


### PR DESCRIPTION
This adds initial monitoring mixins, in order to ease consuming
Zincati metrics on a fleet of Fedora CoreOS nodes. Currently this
only covers Grafana dashboards.
See https://monitoring.mixins.dev/ for general details on
monitoring mixins.

---

Dashboard rendered with metrics from two canary machines ([1](https://fcos-metrics-21.lucabruno.net/bridge?selector=zincati), [2](https://fcos-metrics-31.lucabruno.net/bridge?selector=zincati)):

![mixin](https://user-images.githubusercontent.com/98086/84632405-60e7d400-aede-11ea-8314-d9b15898cf27.png)
