### PR TITLE
docs: add more references to periodic strategy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Features:
  * Agent for [continuous auto-updates][auto-updates], with support for phased rollouts
  * [Configuration][configuration] via TOML dropins and overlaid directories
  * Multiple [update strategies][updates-strategy] for finalization/reboot
- * Internal [metrics][metrics] exposed over a local endpoint
+ * Local [maintenance windows][strategy-periodic] on a weekly schedule for planned upgrades
+ * Internal [metrics][metrics] exposed over a local endpoint in Prometheus format
  * [Logging][logging] with configurable priority levels
- * Support for complex update-graphs in Cincinnati format
- * Support for cluster-wide reboot orchestration, via an external lock-manager
+ * Support for complex update-graphs via [Cincinnati protocol][cincinnati-protocol] (with rollout wariness, barriers, dead-ends and more)
+ * Support for [cluster-wide reboot orchestration][strategy-fleetlock], via an external lock-manager
 
 ![cluster reboot graph](./docs/images/metrics.png)
 
@@ -24,5 +25,8 @@ Features:
 [auto-updates]: ./docs/usage/auto-updates.md
 [configuration]: ./docs/usage/configuration.md
 [updates-strategy]: ./docs/usage/updates-strategy.md
+[strategy-periodic]: ./docs/usage/updates-strategy.md#periodic-strategy
 [metrics]: ./docs/usage/metrics.md
 [logging]: ./docs/usage/logging.md
+[cincinnati-protocol]: ./docs/development/cincinnati/protocol.md
+[strategy-fleetlock]: ./docs/usage/updates-strategy.md#lock-based-strategy

--- a/docs/usage/auto-updates.md
+++ b/docs/usage/auto-updates.md
@@ -46,6 +46,7 @@ For such reason, Zincati allows the user to control when a node is allowed to re
 The following finalization strategies are currently available:
  * immediately reboot to apply an update, as soon as it is downloaded and staged locally (`immediate` strategy, see [relevant documentation][strategy-immediate]).
  * use an external lock-manager to reboot a fleet of machines in a coordinated way (`fleet_lock` strategy, see [relevant documentation][strategy-fleet_lock]).
+ * allow reboots only within locally configured maintenance windows, defined on a weekly basis (`periodic` strategy, see [relevant documentation][strategy-periodic]).
 
 By default, the `immediate` strategy is used in order to proactively keep machines up-to-date.
 
@@ -53,6 +54,7 @@ For further documentation on configurations, check the [updates strategy][update
 
 [strategy-immediate]: updates-strategy.md#immediate-strategy
 [strategy-fleet_lock]: updates-strategy.md#lock-based-strategy
+[strategy-periodic]: updates-strategy.md#periodic-strategy
 [updates-strategy]: updates-strategy.md
 
 ## Updates ordering and downgrades


### PR DESCRIPTION
This updates a few lists in docs with relevant items pointing to the
newly introduced `periodic` strategy documentation.