### PR TITLE
strategy: add metrics to track updates strategy configuration

### DIFF
--- a/src/strategy/periodic.rs
+++ b/src/strategy/periodic.rs
@@ -42,6 +42,11 @@ impl StrategyPeriodic {
         Ok(strategy)
     }
 
+    /// Return the measured length of the schedule, in minutes.
+    pub(crate) fn schedule_length_minutes(&self) -> u64 {
+        self.schedule.length_minutes()
+    }
+
     /// Check if finalization is allowed.
     pub(crate) fn can_finalize(&self) -> Pin<Box<dyn Future<Output = Result<bool, Error>>>> {
         let datetime_now = chrono::Utc::now();

--- a/src/weekly/mod.rs
+++ b/src/weekly/mod.rs
@@ -51,7 +51,7 @@ impl WeeklyCalendar {
         self.windows.query_point(timepoint).count() > 0
     }
 
-    /// Return the measured length of the calendar.
+    /// Return the measured length of the calendar, in minutes.
     ///
     /// In case of overlapping windows, measured length is the actual amount
     /// of weekly minutes in the calendar. Overlapped intervals are coalesced
@@ -87,7 +87,7 @@ impl WeeklyCalendar {
         u64::from(measured)
     }
 
-    /// Return total length of all windows in the calendar.
+    /// Return total length of all windows in the calendar, in minutes.
     ///
     /// In case of overlapping windows, total length can be larger than the
     /// actual amount of weekly minutes in the calendar.


### PR DESCRIPTION
This adds two info metrics covering the configured update strategy:
 * `zincati_updates_strategy_mode{strategy="<MODE>"}`
 * `zincati_updates_strategy_periodic_schedule_length_minutes`

The first is an info metrics covering the strategy mode in all cases;
the second only applies to the "periodic" strategy and tracks the
schedule length.

Ref: https://github.com/coreos/zincati/issues/305
