### PR TITLE
strategy: cleanup unused logic

### DIFF
--- a/src/cincinnati/client.rs
+++ b/src/cincinnati/client.rs
@@ -6,10 +6,7 @@
 
 // TODO(lucab): eventually move to its own "cincinnati client library" crate
 
-#![allow(unused)]
-
-use failure::{format_err, Error, Fail, Fallible, ResultExt};
-use futures::future;
+use failure::{Fail, Fallible, ResultExt};
 use futures::prelude::*;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
@@ -154,7 +151,7 @@ impl Client {
     }
 
     /// Map an HTTP response to a service result.
-    async fn map_response(mut response: reqwest::Response) -> Result<Graph, CincinnatiError> {
+    async fn map_response(response: reqwest::Response) -> Result<Graph, CincinnatiError> {
         let status = response.status();
 
         // On success, try to decode graph.
@@ -201,13 +198,6 @@ impl ClientBuilder {
     pub fn query_params(self, params: Option<HashMap<String, String>>) -> Self {
         let mut builder = self;
         builder.query_params = params;
-        builder
-    }
-
-    /// Set (or reset) the HTTP client to use.
-    pub fn http_client(self, hclient: Option<reqwest::Client>) -> Self {
-        let mut builder = self;
-        builder.hclient = hclient;
         builder
     }
 

--- a/src/cincinnati/mod.rs
+++ b/src/cincinnati/mod.rs
@@ -90,13 +90,8 @@ impl Cincinnati {
         &self,
         id: &Identity,
         deployments: BTreeSet<Release>,
-        can_check: bool,
         allow_downgrade: bool,
     ) -> Pin<Box<dyn Future<Output = Option<Release>>>> {
-        if !can_check {
-            return Box::pin(futures::future::ready(None));
-        }
-
         UPDATE_CHECKS.inc();
         log::trace!("checking upstream Cincinnati server for updates");
 

--- a/src/rpm_ostree/cli_status.rs
+++ b/src/rpm_ostree/cli_status.rs
@@ -1,7 +1,5 @@
 //! Interface to `rpm-ostree status --json`.
 
-#![allow(unused)]
-
 use super::Release;
 use failure::{bail, ensure, format_err, Fallible, ResultExt};
 use serde::Deserialize;
@@ -142,7 +140,7 @@ mod tests {
 
     fn mock_status(path: &str) -> Fallible<StatusJSON> {
         let fp = std::fs::File::open(path).unwrap();
-        let mut bufrd = std::io::BufReader::new(fp);
+        let bufrd = std::io::BufReader::new(fp);
         let status: StatusJSON = serde_json::from_reader(bufrd)?;
         Ok(status)
     }

--- a/src/rpm_ostree/mock_tests.rs
+++ b/src/rpm_ostree/mock_tests.rs
@@ -46,7 +46,7 @@ fn test_simple_graph() {
     let client = Cincinnati {
         base_url: mockito::server_url(),
     };
-    let update = runtime.block_on(client.fetch_update_hint(&id, BTreeSet::new(), true, false));
+    let update = runtime.block_on(client.fetch_update_hint(&id, BTreeSet::new(), false));
     m_graph.assert();
 
     let next = update.unwrap();
@@ -98,11 +98,11 @@ fn test_downgrade() {
     };
 
     // Downgrades denied.
-    let upgrade = runtime.block_on(client.fetch_update_hint(&id, BTreeSet::new(), true, false));
+    let upgrade = runtime.block_on(client.fetch_update_hint(&id, BTreeSet::new(), false));
     assert_eq!(upgrade, None);
 
     // Downgrades allowed.
-    let downgrade = runtime.block_on(client.fetch_update_hint(&id, BTreeSet::new(), true, true));
+    let downgrade = runtime.block_on(client.fetch_update_hint(&id, BTreeSet::new(), true));
 
     m_graph.assert();
     let next = downgrade.unwrap();

--- a/src/strategy/fleet_lock.rs
+++ b/src/strategy/fleet_lock.rs
@@ -4,7 +4,6 @@ use crate::config::inputs;
 use crate::fleet_lock::{Client, ClientBuilder};
 use crate::identity::Identity;
 use failure::{format_err, Error, Fallible};
-use futures::future;
 use futures::prelude::*;
 use log::trace;
 use prometheus::IntCounterVec;
@@ -81,15 +80,6 @@ impl StrategyFleetLock {
                 .inc();
             format_err!("lock-manager {} failure: {}", api, e)
         });
-        Box::pin(res)
-    }
-
-    /// Check if fetching updates is allowed
-    pub(crate) fn can_check_and_fetch(&self) -> Pin<Box<dyn Future<Output = Result<bool, Error>>>> {
-        trace!("fleet_lock strategy, can check updates: {}", true);
-
-        // TODO(lucab): https://github.com/coreos/zincati/issues/35
-        let res = future::ok(true);
         Box::pin(res)
     }
 }

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -1,7 +1,5 @@
 //! Update and reboot strategies.
 
-#![allow(unused)]
-
 use crate::config::inputs;
 use crate::identity::Identity;
 use failure::{bail, Fallible};
@@ -64,7 +62,7 @@ impl UpdateStrategy {
     }
 
     /// Check if finalization is allowed at this time.
-    pub(crate) fn can_finalize(&self, _identity: &Identity) -> impl Future<Output = bool> {
+    pub(crate) fn can_finalize(&self) -> impl Future<Output = bool> {
         let lock = match self {
             UpdateStrategy::FleetLock(s) => s.can_finalize(),
             UpdateStrategy::Immediate(s) => s.can_finalize(),
@@ -80,7 +78,7 @@ impl UpdateStrategy {
     }
 
     /// Try to report and enter steady state.
-    pub(crate) fn report_steady(&self, _identity: &Identity) -> impl Future<Output = bool> {
+    pub(crate) fn report_steady(&self) -> impl Future<Output = bool> {
         let unlock = match self {
             UpdateStrategy::FleetLock(s) => s.report_steady(),
             UpdateStrategy::Immediate(s) => s.report_steady(),
@@ -89,22 +87,6 @@ impl UpdateStrategy {
 
         async {
             unlock.await.unwrap_or_else(|e| {
-                error!("{}", e);
-                false
-            })
-        }
-    }
-
-    /// Check if this agent is allowed to check for updates at this time.
-    pub(crate) fn can_check_and_fetch(&self, _identity: &Identity) -> impl Future<Output = bool> {
-        let can_check = match self {
-            UpdateStrategy::FleetLock(s) => s.can_check_and_fetch(),
-            UpdateStrategy::Immediate(s) => s.can_check_and_fetch(),
-            UpdateStrategy::Periodic(s) => s.can_check_and_fetch(),
-        };
-
-        async {
-            can_check.await.unwrap_or_else(|e| {
                 error!("{}", e);
                 false
             })

--- a/src/strategy/periodic.rs
+++ b/src/strategy/periodic.rs
@@ -61,15 +61,6 @@ impl StrategyPeriodic {
     pub(crate) fn report_steady(&self) -> Pin<Box<dyn Future<Output = Result<bool, Error>>>> {
         trace!("periodic strategy, report steady: {}", true);
 
-        // TODO(lucab): https://github.com/coreos/zincati/issues/35
-        let res = future::ok(true);
-        Box::pin(res)
-    }
-
-    pub(crate) fn can_check_and_fetch(&self) -> Pin<Box<dyn Future<Output = Result<bool, Error>>>> {
-        trace!("periodic strategy, can check updates: {}", true);
-
-        // TODO(lucab): https://github.com/coreos/zincati/issues/35
         let res = future::ok(true);
         Box::pin(res)
     }
@@ -101,14 +92,6 @@ mod tests {
         let default = StrategyPeriodic::default();
         let mut runtime = rt::Runtime::new().unwrap();
         let steady = runtime.block_on(default.report_steady()).unwrap();
-        assert_eq!(steady, true);
-    }
-
-    #[test]
-    fn test_can_check_and_fetch() {
-        let default = StrategyPeriodic::default();
-        let mut runtime = rt::Runtime::new().unwrap();
-        let steady = runtime.block_on(default.can_check_and_fetch()).unwrap();
         assert_eq!(steady, true);
     }
 


### PR DESCRIPTION
Cleanup checklist:
 - [x] drop all the unused Identity arguments
 - [x] try dropping the #![allow(unused)] annotation
 - [x] verify whether can_check_and_fetch is effectively a no-op; if so, it can be safely dropped
 - [x] check if we can and it makes sense to avoid boxed-pinned-results and directly return impl Future<Output = bool> in more places
 - [x] check if introducing a trait helps in reducing the amount of matches and repetitive calls

Closes: https://github.com/coreos/zincati/issues/35
Signed-off-by: Allen Bai <abai@redhat.com>