### PR TITLE
strategy: uniformly use config labels

### DIFF
--- a/src/strategy/fleet_lock.rs
+++ b/src/strategy/fleet_lock.rs
@@ -31,6 +31,9 @@ pub(crate) struct StrategyFleetLock {
 }
 
 impl StrategyFleetLock {
+    /// Strategy label/name.
+    pub const LABEL: &'static str = "fleet_lock";
+
     /// Build a new FleetLock strategy.
     pub fn new(cfg: inputs::UpdateInput, identity: &Identity) -> Fallible<Self> {
         // Substitute templated key with agent runtime values.

--- a/src/strategy/immediate.rs
+++ b/src/strategy/immediate.rs
@@ -12,6 +12,9 @@ use std::pin::Pin;
 pub(crate) struct StrategyImmediate {}
 
 impl StrategyImmediate {
+    /// Strategy label/name.
+    pub const LABEL: &'static str = "immediate";
+
     /// Check if finalization is allowed.
     pub(crate) fn can_finalize(&self) -> Pin<Box<dyn Future<Output = Result<bool, Error>>>> {
         trace!("immediate strategy, can finalize updates: {}", true);

--- a/src/strategy/periodic.rs
+++ b/src/strategy/periodic.rs
@@ -18,6 +18,9 @@ pub(crate) struct StrategyPeriodic {
 }
 
 impl StrategyPeriodic {
+    /// Strategy label/name.
+    pub const LABEL: &'static str = "periodic";
+
     /// Build a new periodic strategy.
     pub fn new(cfg: inputs::UpdateInput) -> Fallible<Self> {
         let mut intervals = Vec::with_capacity(cfg.periodic.intervals.len());


### PR DESCRIPTION
This attaches mode-label constants and uses them for
configuration parsing and when forwarding to metrics labels.
It helps making sure that the `Default` implementation has a
uniform behavior and a non-empty value in metrics labels.