### PR TITLE
Release 0.0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.12-alpha.0"
+version = "0.0.12"
 dependencies = [
  "actix",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.12"
+version = "0.0.13-alpha.0"
 dependencies = [
  "actix",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.12-alpha.0"
+version = "0.0.12"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.12"
+version = "0.0.13-alpha.0"
 description = "Update agent for Fedora CoreOS"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]


### PR DESCRIPTION
Changes:
 * strategy: uniformly use config labels
 * strategy: cleanup unused logic
 * contrib: add monitoring mixins
 * rpm-ostree/status: detect and handle staged deployments
 * docs: add more references to periodic strategy section
 * strategy: add metrics to track updates strategy configuration
 * ci: update travis toolchains
 * docs/dev: describe the Cincinnati protocol used by Fedora CoreOS
 * docs/update-strategy: make airlock a link
 * github: create Dependabot config file
 * docs/images: add a sequence diagram for locked reboots
 * docs/dev: add some details on periodic strategy design

Tracker: https://github.com/coreos/zincati/milestone/9?closed=1