### PR TITLE
rpm-ostree: set RPMOSTREE_CLIENT_ID env variable

### DIFF
--- a/src/rpm_ostree/cli_deploy.rs
+++ b/src/rpm_ostree/cli_deploy.rs
@@ -35,7 +35,8 @@ fn invoke_cli(release: Release, allow_downgrade: bool) -> Fallible<Release> {
     let mut cmd = std::process::Command::new("rpm-ostree");
     cmd.arg("deploy")
         .arg("--lock-finalization")
-        .arg(format!("revision={}", release.checksum));
+        .arg(format!("revision={}", release.checksum))
+        .env("RPMOSTREE_CLIENT_ID", "zincati");
     if !allow_downgrade {
         cmd.arg("--disallow-downgrade");
     }

--- a/src/rpm_ostree/cli_finalize.rs
+++ b/src/rpm_ostree/cli_finalize.rs
@@ -21,6 +21,7 @@ pub fn finalize_deployment(release: Release) -> Fallible<Release> {
     let cmd = std::process::Command::new("rpm-ostree")
         .arg("finalize-deployment")
         .arg(&release.checksum)
+        .env("RPMOSTREE_CLIENT_ID", "zincati")
         .output()
         .with_context(|e| format_err!("failed to run rpm-ostree: {}", e))?;
 

--- a/src/rpm_ostree/cli_status.rs
+++ b/src/rpm_ostree/cli_status.rs
@@ -112,7 +112,7 @@ fn booted_json(status: StatusJSON) -> Fallible<DeploymentJSON> {
 /// Introspect deployments (rpm-ostree status).
 fn status_json(booted_only: bool) -> Fallible<StatusJSON> {
     let mut cmd = std::process::Command::new("rpm-ostree");
-    cmd.arg("status");
+    cmd.arg("status").env("RPMOSTREE_CLIENT_ID", "zincati");
 
     // Try to request the minimum scope we need.
     if booted_only {


### PR DESCRIPTION
When calling the rpm-ostree cli set the RPMOSTREE_CLIENT_ID environment
variable to 'zincati' so that rpm-ostree knows which client is calling
it.

Fixes #131

Signed-off-by: Clement Verna <cverna@tutanota.com>