### PR TITLE
identity: add more details to the OS_INFO metrics

### DIFF
--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -25,7 +25,7 @@ lazy_static::lazy_static! {
     static ref OS_INFO: IntGaugeVec = register_int_gauge_vec!(
         "zincati_identity_os_info",
         "Information about the underlying booted OS",
-        &["os_version"]
+        &["os_version", "basearch", "stream", "platform"]
     ).unwrap();
 }
 
@@ -72,7 +72,14 @@ impl Identity {
         }
 
         // Export info-metrics with details about booted deployment.
-        OS_INFO.with_label_values(&[&id.current_os.version]).set(1);
+        OS_INFO
+            .with_label_values(&[
+                &id.current_os.version,
+                &id.basearch,
+                &id.stream,
+                &id.platform,
+            ])
+            .set(1);
 
         Ok(id)
     }


### PR DESCRIPTION
This commit extends the OS_INFO prometheus metric to add the
basearch, stream and platform information.
The final metrics looks like :

```
zincati_identity_os_info{basearch="x86_64",os_version="32.20200629.3.0",platform="qemu",stream="stable"} 1
```

Fixes #120

Signed-off-by: Clement Verna <cverna@tutanota.com>