### PR TITLE
ci: bump toolchain for lints on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
         - cargo test --release
     - name: "Lints with pinned toolchain"
       arch: amd64
-      rust: 1.44.0
+      rust: 1.45.2
       before_script:
         - rustup component add clippy
         - rustup component add rustfmt

--- a/src/weekly/mod.rs
+++ b/src/weekly/mod.rs
@@ -56,6 +56,7 @@ impl WeeklyCalendar {
     /// In case of overlapping windows, measured length is the actual amount
     /// of weekly minutes in the calendar. Overlapped intervals are coalesced
     /// in order to avoid double-counting.
+    #[allow(clippy::reversed_empty_ranges)]
     pub fn length_minutes(&self) -> u64 {
         let mut measured = 0u32;
         let mut last_range = Range {


### PR DESCRIPTION
This updates rustfmt and clippy to latest stable toolchain, for
Travis jobs.