### PR TITLE
cargo: add homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zincati"
 version = "0.0.13-alpha.0"
 description = "Update agent for Fedora CoreOS"
+homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"
 keywords = ["cincinnati", "coreos", "fedora", "rpm-ostree"]
 authors = ["Luca Bruno <luca.bruno@coreos.com>"]


### PR DESCRIPTION
This adds the homepage field to Cargo manifest, pointing it to the
auto-built pages.

Ref: https://coreos.github.io/zincati