### PR TITLE
docs: Fix development link in contributing doc

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,7 +9,7 @@ nav_order: 9
 
 [Development doc-pages][devdocs] cover several aspects of this project, both at low-level (code and logic) and high-level (architecture and design).
 
-[devdocs]: ./development/
+[devdocs]: development.md
 
 ## Release process
 


### PR DESCRIPTION
Unfortunately this make the link point to an "empty" page when viewing directly on GitHub. This could be improved by adding context in the development page.

Preview: https://travier.github.io/zincati/contributing/