### PR TITLE
Release 0.0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.13"
+version = "0.0.14-alpha.0"
 dependencies = [
  "actix",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.13-alpha.0"
+version = "0.0.13"
 dependencies = [
  "actix",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.13"
+version = "0.0.14-alpha.0"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.13-alpha.0"
+version = "0.0.13"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
 * identity: add more details to the OS_INFO metrics
 * rpm-ostree: set RPMOSTREE_CLIENT_ID env variable
 * metrics: expose process start timestamp
 * github: release checklist cleanups
 * cargo: update prometheus to latest version
 * cargo: add homepage
 * ci: bump toolchain for lints on Travis
 * docs/dev: add FleetLock protocol specs
 * docs: Fix development link in contributing doc
 * docs: Add contributing & simplify Jekyll front matter
 * docs: misc cleanups
 * docs: add initial scaffolding for GitHub Pages

Tracker: https://github.com/coreos/zincati/milestone/10?closed=1