### PR TITLE
rpm-ostree: avoid duplicating error causes

### DIFF
--- a/src/rpm_ostree/cli_deploy.rs
+++ b/src/rpm_ostree/cli_deploy.rs
@@ -1,7 +1,7 @@
 //! Interface to `rpm-ostree deploy --lock-finalization`.
 
 use super::Release;
-use failure::{bail, format_err, Fallible, ResultExt};
+use failure::{bail, Fallible, ResultExt};
 use prometheus::IntCounter;
 
 lazy_static::lazy_static! {
@@ -43,7 +43,7 @@ fn invoke_cli(release: Release, allow_downgrade: bool) -> Fallible<Release> {
 
     let out = cmd
         .output()
-        .with_context(|e| format_err!("failed to run rpm-ostree: {}", e))?;
+        .with_context(|_| "failed to run 'rpm-ostree' binary")?;
 
     if !out.status.success() {
         bail!(

--- a/src/rpm_ostree/cli_finalize.rs
+++ b/src/rpm_ostree/cli_finalize.rs
@@ -1,7 +1,7 @@
 //! Interface to `rpm-ostree finalize-deployment`.
 
 use super::Release;
-use failure::{bail, format_err, Fallible, ResultExt};
+use failure::{bail, Fallible, ResultExt};
 use prometheus::IntCounter;
 
 lazy_static::lazy_static! {
@@ -23,7 +23,7 @@ pub fn finalize_deployment(release: Release) -> Fallible<Release> {
         .arg(&release.checksum)
         .env("RPMOSTREE_CLIENT_ID", "zincati")
         .output()
-        .with_context(|e| format_err!("failed to run rpm-ostree: {}", e))?;
+        .with_context(|_| "failed to run 'rpm-ostree' binary")?;
 
     if !cmd.status.success() {
         FINALIZE_FAILURES.inc();

--- a/src/rpm_ostree/cli_status.rs
+++ b/src/rpm_ostree/cli_status.rs
@@ -122,7 +122,7 @@ fn status_json(booted_only: bool) -> Fallible<StatusJSON> {
     let cmdrun = cmd
         .arg("--json")
         .output()
-        .with_context(|e| format_err!("failed to run rpm-ostree: {}", e))?;
+        .with_context(|_| "failed to run 'rpm-ostree' binary")?;
 
     if !cmdrun.status.success() {
         bail!(


### PR DESCRIPTION
This fixes error context on rpm-ostree failed runs in order to
avoid duplicating the underlying error cause. Failure chain already
includes the root cause as the next element, thus there is no need
to also embed it in the parent context.