### PR TITLE
cincinnati: expose dead-end release information via MOTD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,6 +2248,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "tempfile",
  "tokio",
  "toml",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rand = "0.7"
 reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tempfile = "^3.1"
 structopt = "0.3"
 tokio = "0.2"
 toml = "0.5"

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ install:
 	install -D -m 644 -t ${DESTDIR}/usr/lib/sysusers.d dist/sysusers.d/*.conf
 	install -D -m 644 -t ${DESTDIR}/usr/lib/tmpfiles.d dist/tmpfiles.d/*.conf
 	install -D -m 644 -t ${DESTDIR}/usr/share/polkit-1/rules.d dist/polkit-1/rules.d/*.rules
+	install -D -m 644 -t ${DESTDIR}/usr/share/polkit-1/actions dist/polkit-1/actions/*.policy
 
 .PHONY: check
 check:

--- a/dist/polkit-1/actions/org.coreos.zincati.deadend.policy
+++ b/dist/polkit-1/actions/org.coreos.zincati.deadend.policy
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+  <action id="org.coreos.zincati.deadend">
+    <description>Write dead-end release information as an MOTD fragment via Zincati</description>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>no</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/zincati</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv1">deadend</annotate>
+  </action>
+</policyconfig>

--- a/dist/polkit-1/rules.d/zincati.rules
+++ b/dist/polkit-1/rules.d/zincati.rules
@@ -5,4 +5,13 @@ polkit.addRule(function(action, subject) {
         subject.user == "zincati") {
         return polkit.Result.YES;
     }
-})
+});
+
+// Allow Zincati to write dead-end release information as an MOTD fragment.
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.coreos.zincati.deadend" &&  
+        subject.user == "zincati") {
+        return polkit.Result.YES;
+    }
+});
+

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,4 +32,6 @@ impl CliOptions {
 pub(crate) enum CliCommand {
     #[structopt(name = "agent")]
     Agent,
+    #[structopt(name = "deadend")]
+    Deadend { reason: Option<String> },
 }


### PR DESCRIPTION
After checking whether the current Cincinnati node is a dead-end or
not, write out a new MOTD file at `/run/motd.d/deadend.motd`
reflecting the dead-end status. If the current release is a deadend,
a message is printed in the MOTD containing the reason for the
release being a deadend. An info message is also logged. If not a
dead-end release a blank MOTD is written and no message is logged.

To make the final write atomic, a tempfile is written within the
`/run/motd.d/` directory, and renamed to the location
of the complete MOTD to display.

In this case, "pkexec" utility is used to allow Zincati (which runs as
the `zincati` sysuser) to modify root-owned `/run/motd.d/` in order to
write dead-end release information into a MOTD file, and the polkit rule
will ensure that that utility runs only when its invoked by a `zincati-deadend`
binary and the corresponding user is `zincati`.

Resolves: #90
Co-authored by: Robert Fairley (rob.t.fairley@gmail.com)