### PR TITLE
rpm_ostree: Use rename_all = kebab-case

### DIFF
--- a/src/rpm_ostree/cli_status.rs
+++ b/src/rpm_ostree/cli_status.rs
@@ -13,9 +13,9 @@ pub struct StatusJSON {
 
 /// Partial deployment object (only fields relevant to zincati).
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct DeploymentJSON {
     booted: bool,
-    #[serde(rename = "base-checksum")]
     base_checksum: Option<String>,
     #[serde(rename = "base-commit-meta")]
     base_metadata: BaseCommitMetaJSON,

--- a/tests/fixtures/rpm-ostree-status.json
+++ b/tests/fixtures/rpm-ostree-status.json
@@ -39,6 +39,7 @@
       "requested-base-local-replacements" : [
       ],
       "checksum" : "ce718b90ce19c2cac07fa45efdce91aad208a508c98e9f7f572f5aaba76f569a",
+      "base-checksum" : "41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3",
       "regenerate-initramfs" : false,
       "id" : "fedora-coreos-ce718b90ce19c2cac07fa45efdce91aad208a508c98e9f7f572f5aaba76f569a.0",
       "version" : "30.1",


### PR DESCRIPTION
A great thing about serde (as well as structopt) is that
you can achieve a high level of
https://en.wikipedia.org/wiki/Don%27t_repeat_yourself

Use `rename_all` here because that's the naming standard,
and if we start parsing other values then we don't
need to specify a rename attribute for each one.