### PR TITLE
cargo: remove carets from semver requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,38 +10,38 @@ repository = "https://github.com/coreos/zincati"
 edition = "2018"
 
 [dependencies]
-actix = "^0.10"
-cfg-if = "^0.1"
-chrono = { version = "^0.4", features = ["serde"] }
-env_logger = "^0.7"
-envsubst = "^0.2"
-fail = "^0.4"
-failure = "^0.1"
-futures = "^0.3"
-glob = "^0.3"
-intervaltree = "^0.2.6"
-lazy_static = "^1.4"
-libc = "^0.2"
-liboverdrop = "^0.0.2"
-libsystemd = "^0.2"
-log = "^0.4"
-maplit = "^1.0"
-num-traits = "^0.2"
-ordered-float = { version = "^2.0", features = ["serde"] }
-prometheus = { version = "^0.10", default-features = false }
-rand = "^0.7"
-reqwest = { version = "^0.10", features = ["json"] }
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
-structopt = "^0.3"
-tokio = "^0.2"
-toml = "^0.5"
-url_serde = "^0.2"
+actix = "0.10"
+cfg-if = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+env_logger = "0.7"
+envsubst = "0.2"
+fail = "0.4"
+failure = "0.1"
+futures = "0.3"
+glob = "0.3"
+intervaltree = "0.2.6"
+lazy_static = "1.4"
+libc = "0.2"
+liboverdrop = "0.0.2"
+libsystemd = "0.2"
+log = "0.4"
+maplit = "1.0"
+num-traits = "0.2"
+ordered-float = { version = "2.0", features = ["serde"] }
+prometheus = { version = "0.10", default-features = false }
+rand = "0.7"
+reqwest = { version = "0.10", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+structopt = "0.3"
+tokio = "0.2"
+toml = "0.5"
+url_serde = "0.2"
 
 [dev-dependencies]
-http = "^0.2"
-mockito = "^0.27"
-proptest = "^0.10"
+http = "0.2"
+mockito = "0.27"
+proptest = "0.10"
 
 [features]
 failpoints = [ "fail/failpoints" ]


### PR DESCRIPTION
This removes all carets (^) from dependencies, resulting in
semver entries which are semantically equivalent from cargo
point of view.
This repository is starting to accumulate stale dependencies, as
dependabot is having troubles when trying to update them. The
issue seems related to `^` requirements confusing the bot.

Ref: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio