### PR TITLE
ci: bump linting toolchain in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
         - cargo test --release
     - name: "Lints with pinned toolchain"
       arch: amd64
-      rust: 1.45.2
+      rust: 1.47.0
       before_script:
         - rustup component add clippy
         - rustup component add rustfmt


### PR DESCRIPTION
This updates the linting toolchain in Travis to latest stable (1.47.0).