### PR TITLE
cli: split subcommands logic out of main

### DIFF
--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -1,0 +1,58 @@
+//! Logic for the `agent` subcommand.
+
+use crate::{config, metrics, rpm_ostree, update_agent};
+use actix::Actor;
+use failure::{Fallible, ResultExt};
+use log::{info, trace};
+use prometheus::IntGauge;
+use structopt::clap::{crate_name, crate_version};
+
+lazy_static::lazy_static! {
+    static ref PROCESS_START_TIME: IntGauge = register_int_gauge!(opts!(
+        "process_start_time_seconds",
+        "Start time of the process since unix epoch in seconds."
+    )).unwrap();
+}
+
+/// Agent subcommand entry-point.
+pub(crate) fn run_agent() -> Fallible<()> {
+    info!(
+        "starting update agent ({} {})",
+        crate_name!(),
+        crate_version!()
+    );
+
+    let settings =
+        config::Settings::assemble().context("failed to assemble configuration settings")?;
+    info!(
+        "agent running on node '{}', in update group '{}'",
+        settings.identity.node_uuid.lower_hex(),
+        settings.identity.group
+    );
+
+    // Expose process start timestamp.
+    let start_time = chrono::Utc::now();
+    PROCESS_START_TIME.set(start_time.timestamp());
+
+    trace!("creating actor system");
+    let sys = actix::System::builder()
+        .name(crate_name!())
+        .stop_on_panic(true)
+        .build();
+
+    trace!("creating metrics service");
+    let _metrics_addr = metrics::MetricsService::bind_socket()?.start();
+
+    trace!("creating rpm-ostree client");
+    let rpm_ostree_addr = rpm_ostree::RpmOstreeClient::start(1);
+
+    trace!("creating update agent");
+    let agent = update_agent::UpdateAgent::with_config(settings, rpm_ostree_addr)
+        .context("failed to assemble update-agent from configuration settings")?;
+    let _addr = agent.start();
+
+    trace!("starting actor system");
+    sys.run().context("agent failed")?;
+
+    Ok(())
+}

--- a/src/cli/deadend.rs
+++ b/src/cli/deadend.rs
@@ -1,0 +1,43 @@
+//! Logic for the `deadend` subcommand.
+
+use failure::{bail, Fallible, ResultExt};
+use std::fs::Permissions;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+
+/// Deadend subcommand entry point.
+pub(crate) fn run_deadend(reason: Option<String>) -> Fallible<()> {
+    if reason.is_some() {
+        // Avoid showing partially-written messages using tempfile and
+        // persist (rename).
+        let mut f = tempfile::Builder::new()
+            .prefix(".deadend.")
+            .suffix(".motd.partial")
+            // Create the tempfile in the same directory as the final MOTD,
+            // to ensure proper SELinux labels are applied to the tempfile
+            // before renaming.
+            .tempfile_in("/run/motd.d")
+            .with_context(|e| format!("failed to create temporary MOTD file: {}", e))?;
+        // Set correct permissions of the temporary file, before moving to
+        // the destination (`tempfile` creates files with mode 0600).
+        std::fs::set_permissions(f.path(), Permissions::from_mode(0o644))
+            .with_context(|e| format!("failed to set permissions of temporary MOTD file: {}", e))?;
+
+        if let Some(reason) = reason {
+            writeln!(
+                f,
+                "This release is a dead-end and won't auto-update: {}",
+                reason
+            )
+            .with_context(|e| format!("failed to write MOTD: {}", e))?;
+        }
+
+        f.persist("/run/motd.d/85-zincati-deadend.motd")
+            .with_context(|e| format!("failed to persist temporary MOTD file: {}", e))?;
+    } else if let Err(e) = std::fs::remove_file("/run/motd.d/85-zincati-deadend.motd") {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            bail!("failed to remove dead-end release info file: {}", e);
+        }
+    }
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,7 @@
-//! Command-line interface (CLI) logic.
+//! Command-Line Interface (CLI) logic.
+
+mod agent;
+mod deadend;
 
 use log::LevelFilter;
 use structopt::StructOpt;
@@ -23,6 +26,14 @@ impl CliOptions {
             1 => LevelFilter::Info,
             2 => LevelFilter::Debug,
             _ => LevelFilter::Trace,
+        }
+    }
+
+    /// Dispatch CLI subcommand.
+    pub(crate) fn run(self) -> failure::Fallible<()> {
+        match self.cmd {
+            CliCommand::Agent => agent::run_agent(),
+            CliCommand::Deadend { reason } => deadend::run_deadend(reason),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-//! Update agent.
+//! Agent for Fedora CoreOS auto-updates.
 
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
@@ -10,7 +10,6 @@ extern crate prometheus;
 
 // Cincinnati client.
 mod cincinnati;
-/// Command-line options.
 mod cli;
 /// File-based configuration.
 mod config;
@@ -29,23 +28,8 @@ mod update_agent;
 /// Logic for weekly maintenance windows.
 mod weekly;
 
-use actix::Actor;
-use failure::{bail, ResultExt};
-use log::{info, trace};
-use prometheus::IntGauge;
-use std::fs::Permissions;
-use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
-use std::{fs, io};
-use structopt::clap::{crate_name, crate_version};
+use structopt::clap::crate_name;
 use structopt::StructOpt;
-
-lazy_static::lazy_static! {
-    static ref PROCESS_START_TIME: IntGauge = register_int_gauge!(opts!(
-        "process_start_time_seconds",
-        "Start time of the process since unix epoch in seconds."
-    )).unwrap();
-}
 
 /// Binary entrypoint, for all CLI subcommands.
 fn main() {
@@ -53,7 +37,7 @@ fn main() {
     std::process::exit(exit_code);
 }
 
-// Run till completion or failure, pretty-printing termination errors if any.
+/// Run till completion or failure, pretty-printing termination errors if any.
 fn run() -> i32 {
     // Parse command-line options.
     let cli_opts = cli::CliOptions::from_args();
@@ -66,105 +50,24 @@ fn run() -> i32 {
         .init();
 
     // Dispatch CLI subcommand.
-    let exit = match cli_opts.cmd {
-        cli::CliCommand::Agent => run_agent(),
-        cli::CliCommand::Deadend { reason } => write_deadend_release_info(reason),
-    };
-
-    match exit {
+    match cli_opts.run() {
         Ok(_) => libc::EXIT_SUCCESS,
         Err(e) => {
-            let mut err_chain = e.iter_chain();
-            let top_err = match err_chain.next() {
-                Some(e) => e.to_string(),
-                None => "(unspecified failure)".to_string(),
-            };
-            log::error!("critical error: {}", top_err);
-            for err in err_chain {
-                log::error!(" -> {}", err);
-            }
-
+            log_error_chain(e);
             libc::EXIT_FAILURE
         }
     }
 }
 
-/// Agent subcommand entry-point.
-fn run_agent() -> failure::Fallible<()> {
-    info!(
-        "starting update agent ({} {})",
-        crate_name!(),
-        crate_version!()
-    );
-
-    let settings =
-        config::Settings::assemble().context("failed to assemble configuration settings")?;
-    info!(
-        "agent running on node '{}', in update group '{}'",
-        settings.identity.node_uuid.lower_hex(),
-        settings.identity.group
-    );
-
-    // Expose process start timestamp.
-    let start_time = chrono::Utc::now();
-    PROCESS_START_TIME.set(start_time.timestamp());
-
-    trace!("creating actor system");
-    let sys = actix::System::builder()
-        .name(crate_name!())
-        .stop_on_panic(true)
-        .build();
-
-    trace!("creating metrics service");
-    let _metrics_addr = metrics::MetricsService::bind_socket()?.start();
-
-    trace!("creating rpm-ostree client");
-    let rpm_ostree_addr = rpm_ostree::RpmOstreeClient::start(1);
-
-    trace!("creating update agent");
-    let agent = update_agent::UpdateAgent::with_config(settings, rpm_ostree_addr)
-        .context("failed to assemble update-agent from configuration settings")?;
-    let _addr = agent.start();
-
-    trace!("starting actor system");
-    sys.run().context("agent failed")?;
-
-    Ok(())
-}
-
-/// Deadend subcommand entry point.
-fn write_deadend_release_info(reason: Option<String>) -> failure::Fallible<()> {
-    if reason.is_some() {
-        // Avoid showing partially-written messages using tempfile and
-        // persist (rename).
-        let mut f = tempfile::Builder::new()
-            .prefix(".deadend.")
-            .suffix(".motd.partial")
-            // Create the tempfile in the same directory as the final MOTD,
-            // to ensure proper SELinux labels are applied to the tempfile
-            // before renaming.
-            .tempfile_in("/run/motd.d")
-            .with_context(|e| format!("failed to create temporary MOTD file: {}", e))?;
-        // Set correct permissions of the temporary file, before moving to
-        // the destination (`tempfile` creates files with mode 0600).
-        fs::set_permissions(f.path(), Permissions::from_mode(0o644))
-            .with_context(|e| format!("failed to set permissions of temporary MOTD file: {}", e))?;
-
-        if let Some(reason) = reason {
-            writeln!(
-                f,
-                "This release is a dead-end and won't auto-update: {}",
-                reason
-            )
-            .with_context(|e| format!("failed to write MOTD: {}", e))?;
-        }
-
-        f.persist("/run/motd.d/85-zincati-deadend.motd")
-            .with_context(|e| format!("failed to persist temporary MOTD file: {}", e))?;
-    } else if let Err(e) = std::fs::remove_file("/run/motd.d/85-zincati-deadend.motd") {
-        if e.kind() != io::ErrorKind::NotFound {
-            bail!("failed to remove dead-end release info file: {}", e);
-        }
+/// Pretty-print a chain of errors, as a series of error-priority log messages.
+fn log_error_chain(err_chain: failure::Error) {
+    let mut chain_iter = err_chain.iter_chain();
+    let top_err = match chain_iter.next() {
+        Some(e) => e.to_string(),
+        None => "(unspecified failure)".to_string(),
+    };
+    log::error!("critical error: {}", top_err);
+    for err in chain_iter {
+        log::error!(" -> {}", err);
     }
-    Ok(())
 }


### PR DESCRIPTION
This splits and moves subcommands logic out of main, into their own
`cli` modules.