### PR TITLE
docs/dev: fix fleetlock documentation

### DIFF
--- a/docs/development/fleetlock/protocol.md
+++ b/docs/development/fleetlock/protocol.md
@@ -70,7 +70,7 @@ Request body:
 
 {
   "client_params": {
-    "group": "default",
+    "group": "workers",
     "id": "c988d2509fdf5cdcbed39037c56406fb"
   }
 }

--- a/src/fleet_lock/mod.rs
+++ b/src/fleet_lock/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! This module implements a client for FleetLock, a bare HTTP
 //! protocol for managing cluster-wide reboot via a remote
-//! lock manager. Protocol specification is currently in progress at
-//! https://github.com/coreos/airlock/pull/1.
+//! lock manager. Protocol specification is available at
+//! https://coreos.github.io/zincati/development/fleetlock/protocol/ .
 
 use crate::identity::Identity;
 use failure::{Fail, Fallible, ResultExt};


### PR DESCRIPTION
- Fix an error in fleet lock request example (group named `default` in the example request, but named `workers` in the paragraph before)
- Update to new fleet lock spec location
