### PR TITLE
zincati.service: run after systemd-machine-id-commit.service

### DIFF
--- a/dist/systemd/system/zincati.service
+++ b/dist/systemd/system/zincati.service
@@ -8,6 +8,10 @@ After=network.target
 # this prevents rolling out broken updates to all nodes in the fleet.
 Requires=boot-complete.target
 After=boot-complete.target
+# Make sure we don't inadvertently reboot the system before a machine-id is
+# created so that we don't cause ConditionFirstBoot=true units to run twice
+# See discussions in https://github.com/systemd/systemd/issues/4511.
+After=systemd-machine-id-commit.service
 
 [Service]
 User=zincati


### PR DESCRIPTION
Otherwise, it's possible that the reboot we trigger will have
`ConditionFirstBoot=true` services run again because systemd didn't have
time to write `/etc/machine-id`.

Symmetrically, all services (ours or user-provided ones) which use
`ConditionFirstBoot=true` must learn to use
`Before=first-boot-complete.target` (which is just before
`systemd-machine-id-commit.service`).

This is more of a theoretical issue than anything given how long Zincati
and rpm-ostree realistically take to trigger, download, and stage an
update. OTOH, we can't be 100% sure no user-provided service will ever
hit this race.

For more details, see discussions in:
https://github.com/systemd/systemd/issues/4511