### PR TITLE
github: update the release instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -27,7 +27,7 @@ Push access to the upstream repository is required in order to publish the new t
   - [ ] `RELEASE_VER=x.y.z`
   - [ ] `UPSTREAM_REMOTE=origin`
 
-:warning:: `UPSTREAM_REMOTE` should reference the locally configured remote that points to the upstream git repository.
+:warning:: `UPSTREAM_REMOTE` should reference the locally configured remote that points to the upstream git repository i.e. `git@github.com:coreos/zincati.git`.
 
 - create release commits on a dedicated branch and tag it:
   - [ ] `git checkout -b release-${RELEASE_VER}`
@@ -48,7 +48,7 @@ Push access to the upstream repository is required in order to publish the new t
   - [ ] `cargo publish`
 
 - publish the release:
-  - [ ] open a web browser and create a GitHub Release for the tag above
+  - [ ] find the new tag in the [GitHub tag list](https://github.com/coreos/zincati/tags) and click the triple dots menu, and create a release for it
   - [ ] write a short changelog (i.e. re-use the PR content) and publish the release
 
 - clean up the local environment (optional, but recommended):


### PR DESCRIPTION
This will update the release instructions to clarify the step while publishing a release and the `UPSTREAM_REMOTE` keyword.