### PR TITLE
cli/deadend: split explicit set/unset verbs and logic

### DIFF
--- a/dist/polkit-1/actions/org.coreos.zincati.deadend.policy
+++ b/dist/polkit-1/actions/org.coreos.zincati.deadend.policy
@@ -11,6 +11,6 @@
       <allow_active>no</allow_active>
     </defaults>
     <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/zincati</annotate>
-    <annotate key="org.freedesktop.policykit.exec.argv1">deadend</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv1">deadend-motd</annotate>
   </action>
 </policyconfig>

--- a/src/cincinnati/mod.rs
+++ b/src/cincinnati/mod.rs
@@ -175,7 +175,9 @@ fn refresh_deadend_status(node: &Node) -> failure::Fallible<()> {
                 log::warn!("current release detected as dead-end, reason: {}", reason);
                 std::process::Command::new("pkexec")
                     .arg("/usr/libexec/zincati")
-                    .arg("deadend")
+                    .arg("deadend-motd")
+                    .arg("set")
+                    .arg("--reason")
                     .arg(reason)
                     .output()
                     .with_context(|_| "failed to write dead-end release information")?;
@@ -189,7 +191,8 @@ fn refresh_deadend_status(node: &Node) -> failure::Fallible<()> {
                 log::info!("current release detected as not a dead-end");
                 std::process::Command::new("pkexec")
                     .arg("/usr/libexec/zincati")
-                    .arg("deadend")
+                    .arg("deadend-motd")
+                    .arg("unset")
                     .output()
                     .with_context(|_| "failed to remove dead-end release MOTD file")?;
                 DEADEND_STATE.set_no_deadend();

--- a/src/cli/deadend.rs
+++ b/src/cli/deadend.rs
@@ -4,51 +4,80 @@ use failure::{bail, Fallible, ResultExt};
 use std::fs::Permissions;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
+use structopt::StructOpt;
 
 /// Absolute path to the MOTD fragments directory.
 static MOTD_FRAGMENTS_DIR: &str = "/run/motd.d/";
 /// Absolute path to the MOTD fragment with deadend state.
 static DEADEND_MOTD_PATH: &str = "/run/motd.d/85-zincati-deadend.motd";
 
-/// Deadend subcommand entry point.
-pub(crate) fn run_deadend(reason: Option<String>) -> Fallible<()> {
-    if let Some(content) = reason {
-        // Avoid showing partially-written messages using tempfile and
-        // persist (rename).
-        let mut f = tempfile::Builder::new()
-            .prefix(".deadend.")
-            .suffix(".motd.partial")
-            // Create the tempfile in the same directory as the final MOTD,
-            // to ensure proper SELinux labels are applied to the tempfile
-            // before renaming.
-            .tempfile_in(MOTD_FRAGMENTS_DIR)
-            .context(format!(
-                "failed to create temporary MOTD file under '{}'",
-                MOTD_FRAGMENTS_DIR
-            ))?;
-        // Set correct permissions of the temporary file, before moving to
-        // the destination (`tempfile` creates files with mode 0600).
-        std::fs::set_permissions(f.path(), Permissions::from_mode(0o644)).context(format!(
-            "failed to set permissions of temporary MOTD file at '{}'",
-            f.path().display()
-        ))?;
+/// Subcommand `deadend-motd`.
+#[derive(Debug, StructOpt)]
+pub enum Cmd {
+    /// Set deadend state, with given reason.
+    #[structopt(name = "set")]
+    Set {
+        #[structopt(long = "reason")]
+        reason: String,
+    },
+    /// Unset deadend state.
+    #[structopt(name = "unset")]
+    Unset,
+}
 
-        writeln!(
-            f,
-            "This release is a dead-end and will not further auto-update: {}",
-            content
-        )
-        .and_then(|_| f.flush())
+impl Cmd {
+    /// `deadend-motd` subcommand entry point.
+    pub(crate) fn run(self) -> Fallible<()> {
+        match self {
+            Cmd::Set { reason } => refresh_motd_fragment(reason),
+            Cmd::Unset => remove_motd_fragment(),
+        }
+    }
+}
+
+/// Refresh MOTD fragment with deadend reason.
+fn refresh_motd_fragment(reason: String) -> Fallible<()> {
+    // Avoid showing partially-written messages using tempfile and
+    // persist (rename).
+    let mut f = tempfile::Builder::new()
+        .prefix(".deadend.")
+        .suffix(".motd.partial")
+        // Create the tempfile in the same directory as the final MOTD,
+        // to ensure proper SELinux labels are applied to the tempfile
+        // before renaming.
+        .tempfile_in(MOTD_FRAGMENTS_DIR)
         .context(format!(
-            "failed to write MOTD content to '{}'",
-            f.path().display()
+            "failed to create temporary MOTD file under '{}'",
+            MOTD_FRAGMENTS_DIR
         ))?;
+    // Set correct permissions of the temporary file, before moving to
+    // the destination (`tempfile` creates files with mode 0600).
+    std::fs::set_permissions(f.path(), Permissions::from_mode(0o644)).context(format!(
+        "failed to set permissions of temporary MOTD file at '{}'",
+        f.path().display()
+    ))?;
 
-        f.persist(DEADEND_MOTD_PATH).context(format!(
-            "failed to persist MOTD fragment to '{}'",
-            DEADEND_MOTD_PATH
-        ))?;
-    } else if let Err(e) = std::fs::remove_file(DEADEND_MOTD_PATH) {
+    writeln!(
+        f,
+        "This release is a dead-end and will not further auto-update: {}",
+        reason
+    )
+    .and_then(|_| f.flush())
+    .context(format!(
+        "failed to write MOTD content to '{}'",
+        f.path().display()
+    ))?;
+
+    f.persist(DEADEND_MOTD_PATH).context(format!(
+        "failed to persist MOTD fragment to '{}'",
+        DEADEND_MOTD_PATH
+    ))?;
+    Ok(())
+}
+
+/// Remove motd fragment file, if any.
+fn remove_motd_fragment() -> Fallible<()> {
+    if let Err(e) = std::fs::remove_file(DEADEND_MOTD_PATH) {
         if e.kind() != std::io::ErrorKind::NotFound {
             bail!(
                 "failed to remove MOTD fragment at '{}': {}",
@@ -58,4 +87,75 @@ pub(crate) fn run_deadend(reason: Option<String>) -> Fallible<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{CliCommand, CliOptions};
+    use structopt::StructOpt;
+
+    #[test]
+    fn test_deadend_motd_set() {
+        {
+            let missing_flag = vec!["zincati", "deadend-motd", "set"];
+            let cli = CliOptions::from_iter_safe(missing_flag);
+            assert!(cli.is_err());
+        }
+        {
+            let missing_reason = vec!["zincati", "deadend-motd", "set", "--reason"];
+            let cli = CliOptions::from_iter_safe(missing_reason);
+            assert!(cli.is_err());
+        }
+        {
+            let mut is_ok = false;
+            let empty_reason = vec!["zincati", "deadend-motd", "set", "--reason", ""];
+            let cli = CliOptions::from_iter_safe(empty_reason).unwrap();
+            if let CliCommand::DeadendMotd(cmd) = &cli.cmd {
+                if let Cmd::Set { reason } = cmd {
+                    assert_eq!(reason, "");
+                    is_ok = true;
+                }
+            }
+            if !is_ok {
+                panic!("unexpected result: {:?}", cli);
+            }
+        }
+        {
+            let mut is_ok = false;
+            let reason_message = vec!["zincati", "deadend-motd", "set", "--reason", "foo"];
+            let cli = CliOptions::from_iter_safe(reason_message).unwrap();
+            if let CliCommand::DeadendMotd(cmd) = &cli.cmd {
+                if let Cmd::Set { reason } = cmd {
+                    assert_eq!(reason, "foo");
+                    is_ok = true;
+                }
+            }
+            if !is_ok {
+                panic!("unexpected result: {:?}", cli);
+            }
+        }
+    }
+
+    #[test]
+    fn test_deadend_motd_unset() {
+        {
+            let extra_flags = vec!["zincati", "deadend-motd", "unset", "--reason", "foo"];
+            let cli = CliOptions::from_iter_safe(extra_flags);
+            assert!(cli.is_err());
+        }
+        {
+            let mut is_ok = false;
+            let unset = vec!["zincati", "deadend-motd", "unset"];
+            let cli = CliOptions::from_iter_safe(unset).unwrap();
+            if let CliCommand::DeadendMotd(cmd) = &cli.cmd {
+                if let Cmd::Unset = cmd {
+                    is_ok = true;
+                }
+            }
+            if !is_ok {
+                panic!("unexpected result: {:?}", cli);
+            }
+        }
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@ mod agent;
 mod deadend;
 
 use log::LevelFilter;
+use structopt::clap::AppSettings;
 use structopt::StructOpt;
 
 /// CLI configuration options.
@@ -33,7 +34,7 @@ impl CliOptions {
     pub(crate) fn run(self) -> failure::Fallible<()> {
         match self.cmd {
             CliCommand::Agent => agent::run_agent(),
-            CliCommand::Deadend { reason } => deadend::run_deadend(reason),
+            CliCommand::DeadendMotd(cmd) => cmd.run(),
         }
     }
 }
@@ -41,8 +42,10 @@ impl CliOptions {
 /// CLI sub-commands.
 #[derive(Debug, StructOpt)]
 pub(crate) enum CliCommand {
+    /// Long-running agent for auto-updates.
     #[structopt(name = "agent")]
     Agent,
-    #[structopt(name = "deadend")]
-    Deadend { reason: Option<String> },
+    /// Set or unset deadend MOTD state.
+    #[structopt(name = "deadend-motd", setting = AppSettings::Hidden)]
+    DeadendMotd(deadend::Cmd),
 }


### PR DESCRIPTION
This reworks the subcommand for deadend MOTD handling into two
explicit verbs:
 * `zincati deadend-motd set --reason <REASON>`
 * `zincati deadend-motd unset`

It also adds tests covering flags parsing for the subcommand.