### PR TITLE
Release 0.0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.14"
+version = "0.0.15-alpha.0"
 dependencies = [
  "actix",
  "cfg-if 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.14-alpha.0"
+version = "0.0.14"
 dependencies = [
  "actix",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.14-alpha.0"
+version = "0.0.14"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.14"
+version = "0.0.15-alpha.0"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
 * cli/deadend: split explicit set/unset verbs and logic
 * docs/dev: describe agent design and actor system
 * github: update the release instructions
 * zincati.service: run after systemd-machine-id-commit.service
 * docs/dev: add graph for actors and interactions
 * cli/deadend: rework errors with relevant context
 * docs/dev: fix fleetlock documentation
 * cincinnati: swap order of dead-end refreshing logic
 * cli: split subcommands logic out of main
 * cincinnati: expose dead-end release information via MOTD
 * ci: bump linting toolchain in Travis
 * cargo: switch to latest url version for serde support
 * cargo: remove carets from semver requirements
 * rpm_ostree: Use rename_all = kebab-case
 * docs/usage: expand logging page
 * cargo: update actix to latest version
 * main: pretty-print critical error on termination
 * rpm-ostree: avoid duplicating error causes

Tracker: https://github.com/coreos/zincati/milestone/11