### PR TITLE
workflows/rust: avoid duplicated runs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,10 @@
 ---
 name: Rust
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This refines the triggering conditions for GH actions in order
to avoid running duplicated jobs on local branches.