### PR TITLE
contrib: add dev container flow

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,25 @@
+---
+name: Containers
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  container-dev:
+    name: "Dev container"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Assemble dev-container
+        run: docker build -f contrib/Dockerfile.dev -t coreos/zincati:dev .
+      - name: Run dev-container
+        run: docker run --rm -v "$(pwd):/source" -v "/tmp/assembler:/assembler" coreos/zincati:dev
+      - name: Archive artifacts (overrides/rootfs)
+        uses: actions/upload-artifact@v2
+        with:
+          name: zincati-overrides-rootfs
+          path: /tmp/assembler/overrides/rootfs/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 RELEASE ?= 0
+TARGETDIR ?= target
 
 ifeq ($(RELEASE),1)
 	PROFILE ?= release
@@ -9,12 +10,15 @@ else
 endif
 
 .PHONY: all
-all:
-	cargo build ${CARGO_ARGS}
+all: build check
+
+.PHONY: build
+build:
+	cargo build "--target-dir=${TARGETDIR}" ${CARGO_ARGS}
 
 .PHONY: install
-install:
-	install -D -t ${DESTDIR}/usr/libexec target/${PROFILE}/zincati
+install: build
+	install -D -t ${DESTDIR}/usr/libexec "${TARGETDIR}/${PROFILE}/zincati"
 	install -D -m 644 -t ${DESTDIR}/usr/lib/zincati/config.d dist/config.d/*.toml
 	install -D -m 644 -t ${DESTDIR}/usr/lib/systemd/system dist/systemd/system/*.service
 	install -D -m 644 -t ${DESTDIR}/usr/lib/sysusers.d dist/sysusers.d/*.conf
@@ -24,4 +28,4 @@ install:
 
 .PHONY: check
 check:
-	cargo test
+	cargo test "--target-dir=${TARGETDIR}"

--- a/contrib/Dockerfile.dev
+++ b/contrib/Dockerfile.dev
@@ -1,0 +1,7 @@
+FROM registry.fedoraproject.org/fedora:33
+RUN dnf install -y cargo openssl-devel make
+WORKDIR /source
+ENV DESTDIR="/assembler/overrides/rootfs"
+ENV TARGETDIR="/assembler/tmp/zincati/target"
+
+ENTRYPOINT ["/usr/bin/make", "all", "install"]


### PR DESCRIPTION
This adds a Dockerfile for a container development image, and wires
it to GitHub workflows.
Additionally, the workflow produces a rootfs-override artifact (with
full-debug binary) that can be directly plugged into coreos-assembler
overrides.