### PR TITLE
strategy: record details on startup

### DIFF
--- a/src/strategy/periodic.rs
+++ b/src/strategy/periodic.rs
@@ -50,6 +50,17 @@ impl StrategyPeriodic {
         self.schedule.length_minutes()
     }
 
+    /// Return the remaining duration to next window, in human terms.
+    pub(crate) fn human_remaining(&self) -> String {
+        let datetime = chrono::Utc::now();
+        let remaining = self.schedule.remaining_to_datetime(&datetime);
+        match remaining {
+            None => "not found".to_string(),
+            Some(ref d) => WeeklyCalendar::human_remaining_duration(d)
+                .unwrap_or_else(|_| "unknown".to_string()),
+        }
+    }
+
     /// Check if finalization is allowed.
     pub(crate) fn can_finalize(&self) -> Pin<Box<dyn Future<Output = Result<bool, Error>>>> {
         let datetime_now = chrono::Utc::now();

--- a/src/update_agent/actor.rs
+++ b/src/update_agent/actor.rs
@@ -157,6 +157,7 @@ impl UpdateAgent {
             if actor.enabled {
                 log::info!("initialization complete, auto-updates logic enabled");
                 actor.state.initialized();
+                actor.strategy.record_details();
             } else {
                 log::warn!("initialization complete, auto-updates logic disabled by configuration");
                 actor.state.end();


### PR DESCRIPTION
This logs an info message on startup, in order to record some
details related to the update strategy in use.
In particular, this is helpful when using the 'periodic' strategy
as it shows the remaining time till the next update window.

Closes: https://github.com/coreos/zincati/issues/305