### PR TITLE
workflows: update linting toolchain to latest stable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
   # Minimum supported Rust version (MSRV)
   ACTION_MSRV_TOOLCHAIN: 1.40.0
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.47.0
+  ACTION_LINTS_TOOLCHAIN: 1.48.0
 
 jobs:
   tests-stable:


### PR DESCRIPTION
This updates the linting toolchain to latest stable (1.48.0).