### PR TITLE
config: set metrics values earlier

### DIFF
--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -24,6 +24,7 @@ pub(crate) fn run_agent() -> Fallible<()> {
 
     let settings =
         config::Settings::assemble().context("failed to assemble configuration settings")?;
+    settings.refresh_metrics();
     info!(
         "agent running on node '{}', in update group '{}'",
         settings.identity.node_uuid.lower_hex(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod inputs;
 use crate::cincinnati::Cincinnati;
 use crate::identity::Identity;
 use crate::strategy::UpdateStrategy;
+use crate::update_agent;
 use failure::{Fallible, ResultExt};
 use serde::Serialize;
 use std::num::NonZeroU64;
@@ -50,6 +51,15 @@ impl Settings {
         let extensions = vec!["toml".to_string()];
         let cfg = inputs::ConfigInput::read_configs(prefixes, &common_path, extensions)?;
         Self::validate(cfg)
+    }
+
+    /// Refresh settings-related metrics values.
+    pub(crate) fn refresh_metrics(&self) {
+        // TODO(lucab): consider adding more metrics here (e.g. steady interval).
+        update_agent::UPDATES_ENABLED.set(i64::from(self.enabled));
+        update_agent::ALLOW_DOWNGRADE.set(i64::from(self.allow_downgrade));
+
+        self.strategy.refresh_metrics();
     }
 
     /// Validate config and return a valid agent settings.

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -54,6 +54,12 @@ impl UpdateStrategy {
 
     /// Record strategy details to metrics and logs.
     pub(crate) fn record_details(&self) {
+        self.refresh_metrics();
+        log::info!("update strategy: {}", self.human_description());
+    }
+
+    /// Refresh strategy-related metrics values.
+    pub(crate) fn refresh_metrics(&self) {
         // Export info-metrics with details about current strategy.
         STRATEGY_MODE
             .with_label_values(&[self.configuration_label()])
@@ -63,8 +69,6 @@ impl UpdateStrategy {
             let sched_length = p.schedule_length_minutes();
             PERIODIC_LENGTH.set(sched_length as i64);
         };
-
-        log::info!("update strategy: {}", self.human_description());
     }
 
     /// Return the configuration label/name for this update strategy.

--- a/src/update_agent/actor.rs
+++ b/src/update_agent/actor.rs
@@ -11,17 +11,9 @@ use std::collections::BTreeSet;
 use std::time::Duration;
 
 lazy_static::lazy_static! {
-    static ref ALLOW_DOWNGRADE: IntGauge = register_int_gauge!(opts!(
-        "zincati_update_agent_updates_allow_downgrade",
-        "Whether downgrades via auto-updates logic are allowed."
-    )).unwrap();
     static ref LAST_REFRESH: IntGauge = register_int_gauge!(opts!(
         "zincati_update_agent_last_refresh_timestamp",
         "UTC timestamp of update-agent last refresh tick."
-    )).unwrap();
-    static ref UPDATES_ENABLED: IntGauge = register_int_gauge!(opts!(
-        "zincati_update_agent_updates_enabled",
-        "Whether auto-updates logic is enabled."
     )).unwrap();
 }
 
@@ -31,11 +23,7 @@ impl Actor for UpdateAgent {
     fn started(&mut self, ctx: &mut Self::Context) {
         trace!("update agent started");
 
-        // TODO(lucab): consider adding more metrics here (e.g. steady interval).
-        UPDATES_ENABLED.set(i64::from(self.enabled));
-
         if self.allow_downgrade {
-            ALLOW_DOWNGRADE.set(1);
             log::warn!("client configuration allows (possibly vulnerable) downgrades via auto-updates logic");
         }
 

--- a/src/update_agent/mod.rs
+++ b/src/update_agent/mod.rs
@@ -23,9 +23,17 @@ const DEFAULT_REFRESH_PERIOD_SECS: u64 = 300; // 5 minutes.
 const MAX_DEPLOY_ATTEMPTS: u8 = 12;
 
 lazy_static::lazy_static! {
+    pub(crate) static ref ALLOW_DOWNGRADE: IntGauge = register_int_gauge!(opts!(
+        "zincati_update_agent_updates_allow_downgrade",
+        "Whether downgrades via auto-updates logic are allowed."
+    )).unwrap();
     static ref LATEST_STATE_CHANGE: IntGauge = register_int_gauge!(opts!(
         "zincati_update_agent_latest_state_change_timestamp",
         "UTC timestamp of update-agent last state change."
+    )).unwrap();
+    pub(crate) static ref UPDATES_ENABLED: IntGauge = register_int_gauge!(opts!(
+        "zincati_update_agent_updates_enabled",
+        "Whether auto-updates logic is enabled."
     )).unwrap();
 }
 


### PR DESCRIPTION
This moves metrics initialization early on, for those values that
are set from configuration settings and are already known at
startup.

Closes: https://github.com/coreos/zincati/issues/420