### PR TITLE
Register as update driver for rpm-ostree

### DIFF
--- a/src/rpm_ostree/actor.rs
+++ b/src/rpm_ostree/actor.rs
@@ -99,3 +99,20 @@ impl Handler<QueryLocalDeployments> for RpmOstreeClient {
         super::cli_status::local_deployments(self, query_msg.omit_staged)
     }
 }
+
+/// Request: Register as the update driver for rpm-ostree.
+#[derive(Debug, Clone)]
+pub struct RegisterAsDriver {}
+
+impl Message for RegisterAsDriver {
+    type Result = Fallible<()>;
+}
+
+impl Handler<RegisterAsDriver> for RpmOstreeClient {
+    type Result = Fallible<()>;
+
+    fn handle(&mut self, _msg: RegisterAsDriver, _ctx: &mut Self::Context) -> Self::Result {
+        trace!("request to register as rpm-ostree update driver");
+        super::cli_deploy::deploy_register_driver()
+    }
+}

--- a/src/rpm_ostree/mod.rs
+++ b/src/rpm_ostree/mod.rs
@@ -4,7 +4,9 @@ mod cli_status;
 pub use cli_status::{invoke_cli_status, parse_basearch, parse_booted, parse_updates_stream};
 
 mod actor;
-pub use actor::{FinalizeDeployment, QueryLocalDeployments, RpmOstreeClient, StageDeployment};
+pub use actor::{
+    FinalizeDeployment, QueryLocalDeployments, RegisterAsDriver, RpmOstreeClient, StageDeployment,
+};
 
 #[cfg(test)]
 mod mock_tests;


### PR DESCRIPTION
Following https://github.com/coreos/rpm-ostree/pull/2459, rpm-ostree
now has a mechanism for third-party update drivers to register as
its update driver.

Register Zincati as the update driver in the "initialization" stage.