### PR TITLE
Release 0.0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.16"
+version = "0.0.17-alpha.0"
 dependencies = [
  "actix",
  "cfg-if 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.16-alpha.0"
+version = "0.0.16"
 dependencies = [
  "actix",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.16-alpha.0"
+version = "0.0.16"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.16"
+version = "0.0.17-alpha.0"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
 * github/release-checklist: generate vendor tarball too
* update-agent: expose current state via sd_notify

Tracker: https://github.com/coreos/zincati/milestone/13?closed=1