### PR TITLE
update-agent: add some delay after first Cincinnati check

### DIFF
--- a/src/update_agent/actor.rs
+++ b/src/update_agent/actor.rs
@@ -113,7 +113,12 @@ impl UpdateAgent {
 
         // State changes trigger immediate tick/action.
         if discriminant(&prev_state) != discriminant(&self.state) {
-            return None;
+            // Unless we're transitioning from ReportedSteady to NoNewUpdate.
+            if !(prev_state == UpdateAgentState::ReportedSteady
+                && self.state == UpdateAgentState::NoNewUpdate)
+            {
+                return None;
+            }
         }
 
         let delay = match self.state {


### PR DESCRIPTION
Generally, state changes trigger immediate ticks; make an exception
for the case where we're transitioning from ReportedSteady to
NoNewUpdates. This will prevent Zincati from performing the first
two polls for updates consecutively with no delay in between.