### PR TITLE
Release 0.0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.18-alpha.0"
+version = "0.0.18"
 dependencies = [
  "actix",
  "cfg-if 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.18"
+version = "0.0.19-alpha.0"
 dependencies = [
  "actix",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.18-alpha.0"
+version = "0.0.18"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.18"
+version = "0.0.19-alpha.0"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
- update-agent: 
  - log finalized deployments at start up
  - broadcast warning immediately before update finalizations
  - add some delay after first Cincinnati check
- cincinnati: 
  - add metric for number of ignored update targets
- rpm-ostree: 
  - cache status to minimize binary invocations
  - expose status-related metrics

Tracker: https://github.com/coreos/zincati/milestone/15?closed=1
