### PR TITLE
github/release-checklist: misc updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -9,18 +9,21 @@ In order to ease downstream packaging of Rust binaries, an archive of vendored d
 
 This guide requires:
 
- * a web browser (and network connectivity)
+ * A web browser (and network connectivity)
  * `git`
- * GPG setup and personal key for signing
+ * [GPG setup][GPG setup] and personal key for signing
  * `cargo` (suggested: latest stable toolchain from [rustup][rustup])
  * `cargo-release` (suggested: `cargo install -f cargo-release`)
  * A verified account on crates.io
  * Write access to this GitHub project
+ * Membership in the [Fedora CoreOS Crates Owners group](https://github.com/orgs/coreos/teams/fedora-coreos-crates-owners/members)
 
 ## Release checklist
 
 These steps show how to release version `x.y.z` on the `origin` remote (this can be checked via `git remote -av`).
 Push access to the upstream repository is required in order to publish the new tag and the PR branch.
+
+:warning:: if `origin` is not the name of the locally configured remote that points to the upstream git repository (i.e. `git@github.com:coreos/zincati.git`), be sure to assign the correct remote name to the `UPSTREAM_REMOTE` variable.
 
 - make sure the project is clean and prepare the environment:
   - [ ] `cargo test`
@@ -29,19 +32,16 @@ Push access to the upstream repository is required in order to publish the new t
   - [ ] `RELEASE_VER=x.y.z`
   - [ ] `UPSTREAM_REMOTE=origin`
 
-:warning:: `UPSTREAM_REMOTE` should reference the locally configured remote that points to the upstream git repository i.e. `git@github.com:coreos/zincati.git`.
-
-- create release commits on a dedicated branch and tag it:
+- create release commits on a dedicated branch and tag it (the commits and tag will be signed with the GPG signing key you configured):
   - [ ] `git checkout -b release-${RELEASE_VER}`
   - [ ] `cargo release` (and confirm the version when prompted)
 
-- open a PR for this release:
+- open and merge a PR for this release:
   - [ ] `git push ${UPSTREAM_REMOTE} release-${RELEASE_VER}`
   - [ ] open a web browser and create a PR for the branch above
   - [ ] make sure the resulting PR contains exactly two commits
   - [ ] in the PR body, write a short changelog with relevant changes since last release
-
-- [ ] get the PR reviewed, approved and merged
+  - [ ] get the PR reviewed, approved and merged
 
 - publish the artifacts (tag and crate):
   - [ ] `git checkout v${RELEASE_VER}`
@@ -50,11 +50,11 @@ Push access to the upstream repository is required in order to publish the new t
   - [ ] `cargo publish`
 
 - assemble vendor archive:
-  - [ ] `cargo vendor`
-  - [ ] `tar -czf target/zincati-${RELEASE_VER}-vendor.tar.gz vendor`
+  - [ ] `cargo vendor target/vendor`
+  - [ ] `tar -czf target/zincati-${RELEASE_VER}-vendor.tar.gz -C target vendor`
 
 - publish the release:
-  - [ ] find the new tag in the [GitHub tag list](https://github.com/coreos/zincati/tags) and click the triple dots menu, and create a release for it
+  - [ ] find the new tag in the [GitHub tag list](https://github.com/coreos/zincati/tags), click the triple dots menu, and create a release for it
   - [ ] write a short changelog (i.e. re-use the PR content) and publish the release
   - [ ] upload `target/zincati-${RELEASE_VER}-vendor.tar.gz`
   - [ ] record digests of local artifacts:
@@ -64,7 +64,6 @@ Push access to the upstream repository is required in order to publish the new t
 
 - clean up the local environment (optional, but recommended):
   - [ ] `cargo clean`
-  - [ ] `rm -rf vendor`
   - [ ] `git checkout master`
   - [ ] `git pull ${UPSTREAM_REMOTE} master`
   - [ ] `git push ${UPSTREAM_REMOTE} :release-${RELEASE_VER}`
@@ -73,3 +72,4 @@ Push access to the upstream repository is required in order to publish the new t
 [cargo-release]: https://github.com/sunng87/cargo-release
 [rustup]: https://rustup.rs/
 [crates-io]: https://crates.io/
+[GPG setup]: https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification


### PR DESCRIPTION
Minor misc updates to make the checklist slightly easier to follow
for first-timers.
Note the requirement to be in the Fedora CoreOS Crates Owners group
on Github.