### PR TITLE
rpmostree: Use Rc for status caching

### DIFF
--- a/src/rpm_ostree/actor.rs
+++ b/src/rpm_ostree/actor.rs
@@ -7,11 +7,12 @@ use failure::Fallible;
 use filetime::FileTime;
 use log::trace;
 use std::collections::BTreeSet;
+use std::rc::Rc;
 
 /// Cache of local deployments.
 #[derive(Clone, Debug)]
 pub struct StatusCache {
-    pub status: StatusJSON,
+    pub status: Rc<StatusJSON>,
     pub mtime: FileTime,
 }
 


### PR DESCRIPTION
Prep for updating to use the rpm-ostree client bindings; I hit
the problem that the current struct doesn't implement `Clone`.

I could have easily added that, but conceptually it's a bit wrong
to have our cache gather some data, immediately do a full copy,
then discard the original.

I tried fighting the borrow checker here to have the function
return a reference; doesn't seem possible.  In the end with this
type of cache I think it's just cleaner to use reference counting;
there's no concerns about circular references etc.