### PR TITLE
rpm-ostree: Use upstream Rust bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+
+[[package]]
 name = "assert-json-diff"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1609,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpmostree-client"
+version = "0.1.0"
+source = "git+https://github.com/coreos/rpm-ostree?rev=3041d648bbce3beaef2d6b69c8461532e508329d#3041d648bbce3beaef2d6b69c8461532e508329d"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,18 +1684,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2357,6 +2374,7 @@ dependencies = [
  "rand 0.8.3",
  "regex",
  "reqwest",
+ "rpmostree-client",
  "serde",
  "serde_json",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ prometheus = { version = "0.11", default-features = false }
 rand = "0.8"
 regex = "1.4"
 reqwest = { version = "0.10", features = ["json"] }
+# Not published to crates.io right now
+rpmostree-client = { git = "https://github.com/coreos/rpm-ostree", rev = "3041d648bbce3beaef2d6b69c8461532e508329d" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "^3.2"

--- a/src/rpm_ostree/actor.rs
+++ b/src/rpm_ostree/actor.rs
@@ -1,6 +1,5 @@
 //! rpm-ostree client actor.
 
-use super::cli_status::StatusJSON;
 use super::Release;
 use actix::prelude::*;
 use failure::Fallible;
@@ -12,7 +11,7 @@ use std::rc::Rc;
 /// Cache of local deployments.
 #[derive(Clone, Debug)]
 pub struct StatusCache {
-    pub status: Rc<StatusJSON>,
+    pub status: Rc<rpmostree_client::Status>,
     pub mtime: FileTime,
 }
 

--- a/src/rpm_ostree/mod.rs
+++ b/src/rpm_ostree/mod.rs
@@ -1,7 +1,8 @@
 mod cli_deploy;
 mod cli_finalize;
 mod cli_status;
-pub use cli_status::{invoke_cli_status, parse_basearch, parse_booted, parse_updates_stream};
+pub use cli_status::query_status;
+use lazy_static::lazy_static;
 
 mod actor;
 pub use actor::{
@@ -15,6 +16,16 @@ use crate::cincinnati::{Node, AGE_INDEX_KEY, CHECKSUM_SCHEME, SCHEME_KEY};
 use failure::{ensure, format_err, Fallible, ResultExt};
 use serde::Serialize;
 use std::cmp::Ordering;
+
+/// Metadata key the base (RPM) architecture; injected by coreos-assembler
+pub(crate) const COSA_BASEARCH: &str = "coreos-assembler.basearch";
+/// Metadata key for the Fedora CoreOS stream, injected by FCOS tooling via cosa.
+pub(crate) const FCOS_STREAM: &str = "fedora-coreos.stream";
+
+lazy_static! {
+    pub(crate) static ref CLI_CLIENT: rpmostree_client::CliClient =
+        rpmostree_client::CliClient::new("zincati");
+}
 
 /// An OS release.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]


### PR DESCRIPTION
 rpm-ostree: Use upstream Rust bindings

Depends: coreos/rpm-ostree#2636

Use the upstream client bindings for the status data.  Note
that some functions switched to returning borrowed `&String`
because there's no need to clone unnecessarily.

An interesting note: In the upstream API, the commit
metadata is exposed as a generic `HashMap<>` because
that's how it's used by both ostree and rpm-ostree.  It'd
be a layering violation for us to hardcode `coreos-assembler.basearch`
in the rpm-ostree git for example, not to mention `fedora-coreos.stream`.
So those constants stay here in zincati.

I dropped the `_json` terminology from various functions
because that's weird - we parsed the data from JSON, but
that's not really very relevant except as an implementation
detail.  It's just a `Deployment`, not a `DeploymentJSON`.

Also I dropped for now the optimization of using `--booted`;
it's not a huge amount of data.  If we care we can re-add that
later.  Note it makes caching more complex because then we
need to carefully check the booted state too.