### PR TITLE
cli: Check if run as `zincati` user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,6 +2109,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,4 +2374,5 @@ dependencies = [
  "tokio",
  "toml",
  "url",
+ "users",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ structopt = "0.3"
 tokio = "0.2"
 toml = "0.5"
 url = { version = "2.2", features = ["serde"] }
+users = "0.11.0"
 
 [dev-dependencies]
 http = "0.2"

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -1,5 +1,6 @@
 //! Logic for the `agent` subcommand.
 
+use super::ensure_zincati_user;
 use crate::{config, metrics, rpm_ostree, update_agent};
 use actix::Actor;
 use failure::{Fallible, ResultExt};
@@ -16,6 +17,7 @@ lazy_static::lazy_static! {
 
 /// Agent subcommand entry-point.
 pub(crate) fn run_agent() -> Fallible<()> {
+    ensure_zincati_user("update agent not running as `zincati` user")?;
     info!(
         "starting update agent ({} {})",
         crate_name!(),

--- a/src/cli/deadend.rs
+++ b/src/cli/deadend.rs
@@ -1,5 +1,6 @@
 //! Logic for the `deadend` subcommand.
 
+use super::ensure_zincati_user;
 use failure::{bail, Fallible, ResultExt};
 use std::fs::Permissions;
 use std::io::Write;
@@ -28,6 +29,7 @@ pub enum Cmd {
 impl Cmd {
     /// `deadend-motd` subcommand entry point.
     pub(crate) fn run(self) -> Fallible<()> {
+        ensure_zincati_user("deadend-motd subcommand must be run by `zincati` user")?;
         match self {
             Cmd::Set { reason } => refresh_motd_fragment(reason),
             Cmd::Unset => remove_motd_fragment(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ mod deadend;
 use log::LevelFilter;
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
+use users::get_current_username;
 
 /// CLI configuration options.
 #[derive(Debug, StructOpt)]
@@ -48,4 +49,16 @@ pub(crate) enum CliCommand {
     /// Set or unset deadend MOTD state.
     #[structopt(name = "deadend-motd", setting = AppSettings::Hidden)]
     DeadendMotd(deadend::Cmd),
+}
+
+/// Return Error with msg if not run by `zincati` user.
+fn ensure_zincati_user(msg: &str) -> failure::Fallible<()> {
+    if let Some(uname) = get_current_username() {
+        if uname == "zincati" {
+            return Ok(());
+        }
+    }
+
+    log::warn!("zincati binary should not be run directly");
+    failure::bail!("{}", msg)
 }


### PR DESCRIPTION
Error out if not run by the `zincati` user for the `agent` and
`deadend-motd` subcommands, since the update agent should only be
running as the `zincati` user and `deadend-motd` should not be used
externally.
The binary is currently already placed in `/usr/libexec` in Fedora, but doing
this for extra safety and clarity.

Closes: https://github.com/coreos/zincati/issues/95

Example output:
```
$ /usr/libexec/zincati agent
[WARN ] zincati binary should not be run directly
[ERROR] critical error: update agent not running as `zincati` user

```
```
$ /usr/libexec/zincati deadend-motd unset
[WARN ] zincati binary should not be run directly
[ERROR] critical error: deadend-motd subcommand must be run by `zincati` user
```