### PR TITLE
cli: make check for user more flexible

### DIFF
--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -1,6 +1,6 @@
 //! Logic for the `agent` subcommand.
 
-use super::ensure_zincati_user;
+use super::ensure_user;
 use crate::{config, metrics, rpm_ostree, update_agent};
 use actix::Actor;
 use failure::{Fallible, ResultExt};
@@ -17,7 +17,7 @@ lazy_static::lazy_static! {
 
 /// Agent subcommand entry-point.
 pub(crate) fn run_agent() -> Fallible<()> {
-    ensure_zincati_user("update agent not running as `zincati` user")?;
+    ensure_user("zincati", "update agent not running as `zincati` user")?;
     info!(
         "starting update agent ({} {})",
         crate_name!(),

--- a/src/cli/deadend.rs
+++ b/src/cli/deadend.rs
@@ -1,6 +1,6 @@
 //! Logic for the `deadend` subcommand.
 
-use super::ensure_zincati_user;
+use super::ensure_user;
 use failure::{bail, Fallible, ResultExt};
 use std::fs::Permissions;
 use std::io::Write;
@@ -29,7 +29,11 @@ pub enum Cmd {
 impl Cmd {
     /// `deadend-motd` subcommand entry point.
     pub(crate) fn run(self) -> Fallible<()> {
-        ensure_zincati_user("deadend-motd subcommand must be run by `zincati` user")?;
+        ensure_user(
+            "root",
+            "deadend-motd subcommand must be run as `root` user, \
+             and should be called by the Zincati agent process",
+        )?;
         match self {
             Cmd::Set { reason } => refresh_motd_fragment(reason),
             Cmd::Unset => remove_motd_fragment(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -51,10 +51,10 @@ pub(crate) enum CliCommand {
     DeadendMotd(deadend::Cmd),
 }
 
-/// Return Error with msg if not run by `zincati` user.
-fn ensure_zincati_user(msg: &str) -> failure::Fallible<()> {
+/// Return Error with msg if not run by user.
+fn ensure_user(user: &str, msg: &str) -> failure::Fallible<()> {
     if let Some(uname) = get_current_username() {
-        if uname == "zincati" {
+        if uname == user {
             return Ok(());
         }
     }


### PR DESCRIPTION
Add a `user` argument to `ensure_user()` so we can ensure different
users flexibly. Specifically, for the `agent` subcommand, we want
to ensure that only the `zincati` user can run it. But for the
`deadend-motd` subcommand, we want to make sure that it is run by
`root`, otherwise, the creation of the MOTD will fail anyway.

Note that `deadend-motd` is still only meant to be called internally by
the `agent` process started by `zincati.service` as the `zincati`
user; but in order to write the MOTD, the `agent` process `pkexec`s
as the `root` user before calling the `deadend-motd` subcommand. This
is the reason that we do not check that user is `zincati`, but `root`,
instead.

Addresses: https://github.com/coreos/zincati/pull/495#discussion_r593107325
Closes https://github.com/coreos/zincati/issues/95 properly.