### PR TITLE
tests/kola: add dead-end MOTD kola test

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,0 +1,45 @@
+---
+layout: default
+nav_order: 7
+parent: Development
+---
+
+# Testing
+
+## Unit Tests
+Unit tests can be run using `make check` (via `cargo test`).
+
+## External Kola Tests
+[External Kola tests][kola-ext-tests] can be found in the `tests/kola/` directory.
+
+### `server` Tests
+The `tests/kola/server/` test directory contains tests that require access to a mock Cincinnati server. This test directory contains a Fedora CoreOS config that does the following:
+- creates a `/var/www/` directory
+- [sets up an HTTP server][kolet-httpd] at `localhost` listening on port `80` serving files from the `/var/www/` directory
+- configures Zincati to use `localhost` as its Cincinnati base URL
+- adds a systemd dropin to set Zincati's journal log verbosity to max (`-vvvv`)
+
+Tests place mock release graphs in `/var/www/` for Zincati to fetch.
+
+### Running the Tests
+A built Fedora CoreOS image is required; it is recommended to use the CoreOS Assembler's [`build-fast` command][cosa-build-fast] for faster iteration.
+
+To run the tests, specify the path to your Zincati project directory and which tests to run using `kola run`'s `-E` option.
+
+Example (run all tests):
+```
+kola run --qemu-image fastbuild-fedora-coreos-zincati-qemu.qcow2 -E /path/to/zincati/ 'ext.zincati.*'
+```
+
+Example (run only the `server` tests):
+```
+kola run --qemu-image fastbuild-fedora-coreos-zincati-qemu.qcow2 -E /path/to/zincati/ 'ext.zincati.server.*'
+```
+
+### Adding Tests
+Refer to kola external tests' [README][kola-ext-quick-start] for instructions on adding additional tests
+
+[kolet-httpd]: https://github.com/coreos/coreos-assembler/blob/master/docs/kola/external-tests.md#http-server
+[cosa-build-fast]: https://coreos.github.io/coreos-assembler/kola/external-tests/#fast-build-and-iteration-on-your-projects-tests
+[kola-ext-tests]: https://coreos.github.io/coreos-assembler/kola/external-tests/
+[kola-ext-quick-start]: https://coreos.github.io/coreos-assembler/kola/external-tests/#quick-start

--- a/tests/kola/server/config.fcc
+++ b/tests/kola/server/config.fcc
@@ -1,0 +1,36 @@
+variant: fcos
+version: 1.1.0
+systemd:
+  units:
+    - name: kolet-httpd.path
+      enabled: true
+      contents: |
+        [Path]
+        PathExists=/var/home/core/kolet
+        [Install]
+        WantedBy=kola-runext.service
+    - name: kolet-httpd.service
+      contents: |
+        [Service]
+        ExecStart=/var/home/core/kolet httpd --path /var/www/ -v
+        [Install]
+        WantedBy=kola-runext.service
+    - name: zincati.service
+      dropins:
+        - name: verbose.conf
+          contents: |
+            [Service]
+            Environment=ZINCATI_VERBOSITY="-vvvv"
+storage:
+  files:
+    - path: /etc/zincati/config.d/99-cincinnati-url.toml
+      contents:
+        inline: cincinnati.base_url="http://localhost"
+      mode: 420
+  directories:
+    - path: /var/www
+      mode: 0666
+      user:
+        name: core
+      group:
+        name: core

--- a/tests/kola/server/test-deadend-release.sh
+++ b/tests/kola/server/test-deadend-release.sh
@@ -1,0 +1,51 @@
+#!/bin/bash     
+
+# Test to check for correct detection of a dead-end release.
+
+set -xeuo pipefail
+
+cd $(mktemp -d)
+
+# Prepare a graph with the current booted deployment as a dead-end.
+mkdir /var/www/v1
+cat <<'EOF' > graph_template
+{
+  "nodes": [
+    {
+      "version": "",
+      "metadata": {
+          "org.fedoraproject.coreos.releases.age_index": "0",
+          "org.fedoraproject.coreos.updates.deadend_reason": "https://github.com/coreos/fedora-coreos-tracker/issues/215",
+          "org.fedoraproject.coreos.scheme": "checksum",
+          "org.fedoraproject.coreos.updates.deadend": "true"
+      },
+      "payload": ""
+    }
+  ],
+  "edges": []
+}
+EOF
+version="$(/usr/bin/rpm-ostree status --json | jq '.deployments[0].version' -r)"
+payload="$(/usr/bin/rpm-ostree status --json | jq '.deployments[0].checksum' -r)"
+jq \
+  --arg version "$version" \
+  --arg payload "$payload" \
+  '.nodes[0].version=$version | .nodes[0].payload=$payload' \
+  graph_template >/var/www/v1/graph
+
+
+# Now let Zincati check for updates (and detect that the current release is a dead-end).
+echo "updates.enabled = true" > /etc/zincati/config.d/99-test-status-updates-enabled.toml
+systemctl restart zincati.service
+
+# Wait up to 60 seconds for Zincati to detect that the current release is a dead-end release.
+for i in {1..60}
+do
+    if test -f /run/motd.d/85-zincati-deadend.motd; then
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "Dead-end MOTD file not found after timeout."
+exit 1


### PR DESCRIPTION
tests/kola: add dead-end MOTD kola test

  Create a new kola test directory that contains a Fedora CoreOS
  config that sets up an HTTP server and configure Zincati to use
  it as its Cincinnati server.
  Include a test to check that Zincati correctly detects a deadend
  release and successfully generates a MOTD.

docs/development: add testing docs
