### PR TITLE
Release 0.0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.19-alpha.0"
+version = "0.0.19"
 dependencies = [
  "actix",
  "cfg-if 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.19"
+version = "0.0.20-alpha.0"
 dependencies = [
  "actix",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.19"
+version = "0.0.20-alpha.0"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.19-alpha.0"
+version = "0.0.19"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
- update-agent:
  - register as update driver for rpm-ostree
  - don't consider transition into own state a "state change"
  - delay reboot if users logged in
  - add update finalization postponement metrics
- cli: 
  - check if run as `zincati` user
  - make check for user more flexible
- rpm-ostree: 
  - Use Rc for status caching

Tracker: https://github.com/coreos/zincati/milestone/16