### PR TITLE
strategy/periodic: support configuring a time zone for reboot windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
+name = "tzfile"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59c22c42a2537e4c7ad21a4007273bbc5bebed7f36bc93730a5780e22a4592e"
+dependencies = [
+ "byteorder",
+ "chrono",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2160,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "tzfile",
  "url",
  "users",
  "zbus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tempfile = "^3.2"
 thiserror = "1.0"
 tokio = { version = "1.5", features = ["rt", "rt-multi-thread"] }
 toml = "0.5"
+tzfile = "0.1.3"
 url = { version = "2.2", features = ["serde"] }
 users = "0.11.0"
 zbus = "1.9.1"

--- a/docs/development/update-strategy-periodic.md
+++ b/docs/development/update-strategy-periodic.md
@@ -10,7 +10,6 @@ The agent supports a `periodic` strategy, which allows gating reboots based on "
 
 This strategy is a port of [locksmith reboot windows][locksmith], with a few differences:
 
- * all times and dates are UTC-based to avoid skews and ambiguities
  * multiple disjoint reboot windows are supported
  * multiple configuration entries are assembled into a single weekly calendar
  * weekdays need to be specified, in either long or abbreviated form
@@ -26,18 +25,22 @@ In order to ease the case where the same time-window has to be applied on multip
 
 The start of a reboot window is a single point in time, specified in 24h format with minutes granularity (e.g. `22:30`) via the `start_time` parameter.
 
-A key part of this logic is that all times and dates are UTC-based, in order to guarantee the correctness of maintenance windows.
-In particular, UTC times are needed to avoid:
+By default, all times and dates are UTC-based.
+UTC times must be used to avoid:
 
- * skipping reboot windows due to Daylight Saving Time time-change
- * overshooting reboot windows due to Daylight Saving Time time-change
+ * shortening or skipping reboot windows due to Daylight Saving Time time-change
+ * lengthening reboot windows due to Daylight Saving Time time-change
  * mixups due to short-notice law changes in time-zone definitions
  * errors due to stale `tzdata` entries
  * human confusion on machines with different local-timezone configurations
 
-Overall this strategy aims at guaranteeing that the total weekly length for reboot windows is respected, regardless of local timezone laws.
+Overall, the use of the default UTC times guarantee that the total weekly length for reboot windows is respected, regardless of local time zone laws.
 
 As a side-effect, this also helps when cross-checking configurations across multiple machines located in different places.
+
+Nevertheless, user-specified non-UTC time zones can still be configured, but with [caveats][time-zone-caveats].
+
+[time-zone-caveats]: ../usage/updates-strategy.md#time-zone-caveats
 
 # Implementation details
 

--- a/src/config/fragments.rs
+++ b/src/config/fragments.rs
@@ -77,6 +77,11 @@ pub(crate) struct UpdateFleetLock {
 pub(crate) struct UpdatePeriodic {
     /// A weekly window.
     pub(crate) window: Option<Vec<UpdatePeriodicWindow>>,
+    /// A time zone in the IANA Time Zone Database (https://www.iana.org/time-zones)
+    /// or "localtime". If unset, UTC is used.
+    ///
+    /// Examples: `America/Toronto`, `Europe/Rome`
+    pub(crate) time_zone: Option<String>,
 }
 
 /// Config fragment for a `periodic.window` entry.
@@ -138,6 +143,7 @@ mod tests {
                             length_minutes: 25,
                         },
                     ]),
+                    time_zone: Some("localtime".to_string()),
                 }),
             }),
         };

--- a/src/config/inputs.rs
+++ b/src/config/inputs.rs
@@ -185,6 +185,9 @@ pub(crate) struct FleetLockInput {
 pub(crate) struct PeriodicInput {
     /// Set of updates windows.
     pub(crate) intervals: Vec<PeriodicIntervalInput>,
+    /// A time zone in the IANA Time Zone Database or "localtime".
+    /// Defaults to "UTC".
+    pub(crate) time_zone: String,
 }
 
 /// Update window for a "periodic" interval.
@@ -203,7 +206,10 @@ impl UpdateInput {
         let mut fleet_lock = FleetLockInput {
             base_url: String::new(),
         };
-        let mut periodic = PeriodicInput { intervals: vec![] };
+        let mut periodic = PeriodicInput {
+            intervals: vec![],
+            time_zone: "UTC".to_string(),
+        };
 
         for snip in fragments {
             if let Some(a) = snip.allow_downgrade {
@@ -221,6 +227,9 @@ impl UpdateInput {
                 }
             }
             if let Some(w) = snip.periodic {
+                if let Some(tz) = w.time_zone {
+                    periodic.time_zone = tz;
+                }
                 if let Some(win) = w.window {
                     for entry in win {
                         for day in entry.days {

--- a/src/strategy/fleet_lock.rs
+++ b/src/strategy/fleet_lock.rs
@@ -103,7 +103,10 @@ mod tests {
             fleet_lock: FleetLockInput {
                 base_url: "https://example.com".to_string(),
             },
-            periodic: PeriodicInput { intervals: vec![] },
+            periodic: PeriodicInput {
+                intervals: vec![],
+                time_zone: "UTC".to_string(),
+            },
         };
 
         let res = StrategyFleetLock::new(input, &id);
@@ -120,7 +123,10 @@ mod tests {
             fleet_lock: FleetLockInput {
                 base_url: String::new(),
             },
-            periodic: PeriodicInput { intervals: vec![] },
+            periodic: PeriodicInput {
+                intervals: vec![],
+                time_zone: "localtime".to_string(),
+            },
         };
 
         let res = StrategyFleetLock::new(input, &id);

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -90,12 +90,9 @@ impl UpdateStrategy {
         match self {
             UpdateStrategy::FleetLock(_) => self.configuration_label().to_string(),
             UpdateStrategy::Immediate(_) => self.configuration_label().to_string(),
-            UpdateStrategy::Periodic(p) => format!(
-                "{}, total schedule length {} minutes (next window {})",
-                self.configuration_label(),
-                p.schedule_length_minutes(),
-                p.human_remaining()
-            ),
+            UpdateStrategy::Periodic(p) => {
+                format!("{}, {}", self.configuration_label(), p.calendar_summary(),)
+            }
         }
     }
 

--- a/src/strategy/periodic.rs
+++ b/src/strategy/periodic.rs
@@ -2,20 +2,40 @@
 
 use crate::config::inputs;
 use crate::weekly::{utils, WeeklyCalendar, WeeklyWindow};
-use anyhow::{Error, Result};
+use anyhow::{Context, Error, Result};
+use chrono::{TimeZone, Utc};
 use fn_error_context::context;
 use futures::future;
 use futures::prelude::*;
 use log::trace;
 use serde::Serialize;
+use std::fs::read_link;
+use std::path::Path;
 use std::pin::Pin;
 use std::time::Duration;
+use tzfile::Tz;
 
 /// Strategy for periodic (weekly) updates.
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct StrategyPeriodic {
     /// Whitelisted time windows during which updates are allowed.
     schedule: WeeklyCalendar,
+    /// Time zone in which time windows are defined in.
+    #[serde(skip_serializing)]
+    pub(crate) time_zone: Tz,
+    /// Time zone name.
+    tz_name: String,
+}
+
+impl Default for StrategyPeriodic {
+    fn default() -> Self {
+        let utc = "UTC";
+        StrategyPeriodic {
+            schedule: WeeklyCalendar::default(),
+            time_zone: Tz::named(utc).unwrap(),
+            tz_name: utc.to_string(),
+        }
+    }
 }
 
 impl StrategyPeriodic {
@@ -25,8 +45,9 @@ impl StrategyPeriodic {
     /// Build a new periodic strategy.
     #[context("failed to parse periodic strategy")]
     pub fn new(cfg: inputs::UpdateInput) -> Result<Self> {
-        let mut intervals = Vec::with_capacity(cfg.periodic.intervals.len());
+        let (time_zone, tz_name) = Self::get_time_zone_info_from_cfg(&cfg.periodic)?;
 
+        let mut intervals = Vec::with_capacity(cfg.periodic.intervals.len());
         for entry in cfg.periodic.intervals {
             let weekday = utils::weekday_from_string(&entry.start_day)?;
             let start = utils::time_from_string(&entry.start_time)?;
@@ -43,13 +64,80 @@ impl StrategyPeriodic {
             n => log::trace!("periodic updates, weekly calendar length: {} minutes", n),
         };
 
-        let strategy = Self { schedule: calendar };
+        let strategy = Self {
+            schedule: calendar,
+            time_zone,
+            tz_name,
+        };
         Ok(strategy)
+    }
+
+    /// Getter function for `StrategyPeriodic`'s `tz_name` field.
+    pub fn tz_name(&self) -> &str {
+        self.tz_name.as_str()
+    }
+
+    /// Get the time zone from `periodic` strategy config, returning a `Tz` and its name
+    /// in a tuple.
+    #[context("failed to get time zone info from config")]
+    fn get_time_zone_info_from_cfg(cfg: &inputs::PeriodicInput) -> Result<(Tz, String)> {
+        let tz;
+        let tz_name;
+        if &cfg.time_zone == "localtime" {
+            let local_time_path = Path::new("/etc/localtime");
+            // Use `read_link()` instead of `exists()` because we only want to check for
+            // the existence of the `/etc/localtime` symlink, not whether it points to
+            // a valid file (`read_link()` returns an error if symlink doesn't exist).
+            if read_link(local_time_path).is_err() {
+                let utc = "UTC";
+                tz = Tz::named(utc)
+                    .with_context(|| format!("failed to parse time zone named: {}", utc));
+                tz_name = utc.to_string();
+            } else {
+                // Until `tzfile::Tz` has some way of getting its name or unique identifier, do
+                // the parsing of `/etc/localtime` ourselves here so we can get a `tz_str` to cache.
+                let tz_path = local_time_path.canonicalize()?;
+                let tz_str = tz_path
+                    .strip_prefix(Path::new("/usr/share/zoneinfo"))
+                    .context(
+                        "`/etc/localtime` does not link to a location in `/usr/share/zoneinfo`",
+                    )?
+                    .to_str()
+                    .unwrap_or_default();
+                tz = Tz::named(tz_str)
+                    .with_context(|| format!("failed to parse time zone named: {}", tz_str));
+                tz_name = tz_str.to_string();
+            }
+        } else {
+            tz = Tz::named(&cfg.time_zone)
+                .with_context(|| format!("failed to parse time zone named: {}", &cfg.time_zone));
+            tz_name = cfg.time_zone.to_string();
+        }
+
+        tz.map(|tz| (tz, tz_name))
     }
 
     /// Return the measured length of the schedule, in minutes.
     pub(crate) fn schedule_length_minutes(&self) -> u64 {
         self.schedule.length_minutes()
+    }
+
+    /// Return the weekday and time of the next window, in human terms.
+    pub(crate) fn human_next_window(&self) -> String {
+        let naive_utc_dt = Utc::now().naive_utc();
+        let dt = (&self.time_zone).from_utc_datetime(&naive_utc_dt);
+        let next_window_minute_in_week = self.schedule.next_window_minute_in_week(&dt);
+
+        match next_window_minute_in_week {
+            Some(minute_in_week) => {
+                let (weekday, hour, minute) = utils::weekly_minute_as_weekday_time(minute_in_week);
+                format!(
+                    "at {}:{} on {} ({}), subject to time zone caveats.",
+                    hour, minute, weekday, self.tz_name
+                )
+            }
+            None => "not found".to_string(),
+        }
     }
 
     /// Return the remaining duration to next window, in human terms.
@@ -63,10 +151,26 @@ impl StrategyPeriodic {
         }
     }
 
+    /// Return some human-friendly information about `PeriodicStrategy`'s calendar.
+    pub(crate) fn calendar_summary(&self) -> String {
+        format!(
+            "total schedule length {} minutes; next window {}",
+            self.schedule_length_minutes(),
+            if self.tz_name() != "UTC" || self.tz_name() != "Etc/UTC" {
+                self.human_next_window()
+            } else {
+                // It is likely difficult for users to reason about UTC dates and times,
+                // so display remaining time, instead.
+                self.human_remaining()
+            }
+        )
+    }
+
     /// Check if finalization is allowed.
     pub(crate) fn can_finalize(&self) -> Pin<Box<dyn Future<Output = Result<bool, Error>>>> {
-        let datetime_now = chrono::Utc::now();
-        let allowed = self.schedule.contains_datetime(&datetime_now);
+        let naive_utc_dt = Utc::now().naive_utc();
+        let dt = (&self.time_zone).from_utc_datetime(&naive_utc_dt);
+        let allowed = self.schedule.contains_datetime(&dt);
 
         trace!("periodic strategy, can finalize updates: {}", allowed);
 
@@ -113,14 +217,95 @@ mod tests {
 
     #[test]
     fn test_periodic_config() {
-        let fp = std::fs::File::open("tests/fixtures/20-periodic-sample.toml").unwrap();
+        let cfg = parse_config_input("tests/fixtures/20-periodic-sample.toml");
+        let strategy = StrategyPeriodic::new(cfg.updates).unwrap();
+        assert_eq!(strategy.schedule.total_length_minutes(), 3145);
+    }
+
+    #[test]
+    fn test_non_utc_time() {
+        use chrono::{Datelike, Timelike};
+
+        // Build a strategy that uses a non UTC time.
+        // Time zone is `America/Toronto` in `30-periodic-sample-non-utc.toml`.
+        let non_utc_time_cfg = parse_config_input("tests/fixtures/30-periodic-sample-non-utc.toml");
+        // Create current datetime with non UTC time.
+        let naive_utc_dt = Utc::now().naive_utc();
+        let tz = Tz::named(&non_utc_time_cfg.updates.periodic.time_zone.clone()).unwrap();
+        let dt = (&tz).from_utc_datetime(&naive_utc_dt);
+        let weekday = dt.weekday();
+        let time = format!("{}:{}", dt.hour(), dt.minute());
+        // Modify time windows to only allow naive time in non-UTC time zone's current and following minute.
+        let mut non_utc_time_update_input: inputs::UpdateInput = non_utc_time_cfg.updates;
+        non_utc_time_update_input.periodic.intervals = vec![inputs::PeriodicIntervalInput {
+            start_day: weekday.to_string(),
+            start_time: time.to_string(),
+            length_minutes: 2,
+        }];
+
+        // Build a strategy that uses UTC.
+        // Time zone is not specified in `20-periodic-sample.toml` and so defaults to UTC.
+        let utc_cfg = parse_config_input("tests/fixtures/20-periodic-sample.toml");
+        // Modify time windows to only allow naive time in non-UTC time zone's current and following minute.
+        let mut utc_update_input: inputs::UpdateInput = utc_cfg.updates;
+        utc_update_input.periodic.intervals = non_utc_time_update_input.periodic.intervals.clone();
+
+        let non_utc_strategy = StrategyPeriodic::new(non_utc_time_update_input).unwrap();
+        let runtime = rt::Runtime::new().unwrap();
+        let steady = runtime.block_on(non_utc_strategy.can_finalize()).unwrap();
+        assert_eq!(
+            non_utc_strategy.time_zone,
+            Tz::named("America/Toronto").unwrap()
+        );
+        // Check that strategy allows reboot now.
+        assert_eq!(steady, true);
+
+        let utc_strategy = StrategyPeriodic::new(utc_update_input).unwrap();
+        let runtime = rt::Runtime::new().unwrap();
+        let steady = runtime.block_on(utc_strategy.can_finalize()).unwrap();
+        assert_eq!(utc_strategy.time_zone, Tz::named("UTC").unwrap());
+        // Check that reboot is NOT allowed for UTC strategy.
+        assert_eq!(steady, false);
+    }
+
+    #[test]
+    fn test_localtime() {
+        use std::matches;
+        use std::path::Path;
+        let local_time_path = Path::new("/etc/localtime");
+        let expected_tz;
+        // If symlink `/etc/localtime` doesn't exist, we expect to default to UTC.
+        if let Err(_) = read_link(local_time_path) {
+            expected_tz = Some(Tz::named("UTC").unwrap());
+        } else {
+            if let Ok(tz_path) = local_time_path.canonicalize() {
+                let tz_str = tz_path
+                    .strip_prefix(Path::new("/usr/share/zoneinfo"))
+                    .unwrap()
+                    .to_str()
+                    .unwrap();
+                expected_tz = Some(Tz::named(tz_str).unwrap());
+            } else {
+                // `/etc/localtime` exists but points to an invalid time zone.
+                expected_tz = None;
+            }
+        }
+        let config = parse_config_input("tests/fixtures/31-periodic-sample-non-utc.toml");
+        let strategy = StrategyPeriodic::new(config.updates);
+        match expected_tz {
+            Some(tz) => assert_eq!(strategy.unwrap().time_zone, tz),
+            // If we couldn't canonicalize `/etc/localtime` i.e. it points to an invalid
+            // location, make sure that we fail to create a new `StrategyPeriodic` struct.
+            None => assert!(matches!(strategy, Err { .. })),
+        }
+    }
+
+    fn parse_config_input(config_path: &str) -> inputs::ConfigInput {
+        let fp = std::fs::File::open(config_path).unwrap();
         let mut bufrd = std::io::BufReader::new(fp);
         let mut content = vec![];
         bufrd.read_to_end(&mut content).unwrap();
         let frag: fragments::ConfigFragment = toml::from_slice(&content).unwrap();
-        let cfg = inputs::ConfigInput::merge_fragments(vec![frag]);
-
-        let strategy = StrategyPeriodic::new(cfg.updates).unwrap();
-        assert_eq!(strategy.schedule.total_length_minutes(), 3145);
+        inputs::ConfigInput::merge_fragments(vec![frag])
     }
 }

--- a/tests/fixtures/00-config-sample.toml
+++ b/tests/fixtures/00-config-sample.toml
@@ -17,6 +17,9 @@ strategy = "fleet_lock"
 [updates.fleet_lock]
 base_url = "http://fleet-lock.example.com:8080/"
 
+[updates.periodic]
+time_zone = "localtime"
+
 [[updates.periodic.window]]
 days = [ "Sat", "Sun" ]
 start_time = "23:00"

--- a/tests/fixtures/30-periodic-sample-non-utc.toml
+++ b/tests/fixtures/30-periodic-sample-non-utc.toml
@@ -1,0 +1,10 @@
+[updates]
+strategy = "periodic"
+
+[updates.periodic]
+time_zone = "America/Toronto"
+
+[[updates.periodic.window]]
+days = [ "Mon" ]
+start_time = "00:00"
+length_minutes = 120

--- a/tests/fixtures/31-periodic-sample-non-utc.toml
+++ b/tests/fixtures/31-periodic-sample-non-utc.toml
@@ -1,0 +1,10 @@
+[updates]
+strategy = "periodic"
+
+[updates.periodic]
+time_zone = "localtime"
+
+[[updates.periodic.window]]
+days = [ "Wed" ]
+start_time = "23:00"
+length_minutes = 30


### PR DESCRIPTION
Support configuring reboot windows defined by a user-specified time zone, instead of only UTC.

Include a single `time_zone` field (that defaults to UTC if not
specified) in the `periodic` strategy's configuration. Whenever we
need to check whether we're currently in an allowed reboot window,
we convert the current naive time to the naive time under the
specified time zone, and check whether we are currently in a reboot
window.

Under this implementation, we keep invariant clock time for reboots,
but do NOT keep invariant reboot window length; thus, in some cases,
reboot windows can be lengthened, shortened, or skipped entirely.