### PR TITLE
doc/quickstart: use FCOS buildroot image

### DIFF
--- a/contrib/Dockerfile.dev
+++ b/contrib/Dockerfile.dev
@@ -1,7 +1,0 @@
-FROM registry.fedoraproject.org/fedora:33
-RUN dnf install -y cargo openssl-devel make
-WORKDIR /source
-ENV DESTDIR="/assembler/overrides/rootfs"
-ENV TARGETDIR="/assembler/tmp/zincati/target"
-
-ENTRYPOINT ["/usr/bin/make", "all", "install"]

--- a/docs/development/quickstart.md
+++ b/docs/development/quickstart.md
@@ -44,14 +44,14 @@ make build
 make check
 ```
 
-If you prefer running builds in a containerized environment, you can use the provided `Dockerfile`:
+If you prefer running builds in a containerized environment, you can use the FCOS buildroot image at `quay.io/coreos-assembler/fcos-buildroot:testing-devel`:
 
 ```sh
-docker build -f contrib/Dockerfile.dev -t coreos/zincati:dev .
-docker run --rm -v "$(pwd):/source" -v "/tmp/assembler:/assembler" coreos/zincati:dev
+docker pull quay.io/coreos-assembler/fcos-buildroot:testing-devel
+docker run --rm -v "$(pwd):/source:z" quay.io/coreos-assembler/fcos-buildroot:testing-devel bash -c "cd source; make"
 ```
 
-There is also a larger buildroot image at `registry.svc.ci.openshift.org/coreos/cosa-buildroot:latest`, which is used by integration jobs in CI.
+The FCOS buildroot image is the same image that is used by integration jobs in CI.
 It contains all the required dependencies and can be used to build other CoreOS projects too (not only Zincati).
 
 ## Assemble custom OS images
@@ -66,8 +66,9 @@ mkdir test-image
 cd test-image
 cosa init https://github.com/coreos/fedora-coreos-config
 popd
-docker build -f contrib/Dockerfile.dev -t coreos/zincati:dev .
-docker run --rm -v "$(pwd):/source" -v "/tmp/test-image:/assembler" coreos/zincati:dev
+docker run --rm -v "$(pwd):/source:z" -v "/tmp/test-image:/assembler:z" \
+    -e DESTDIR="/assembler/overrides/rootfs" -e TARGETDIR="/assembler/tmp/zincati/target" \
+    quay.io/coreos-assembler/fcos-buildroot:testing-devel bash -c "cd source; make install"
 pushd /tmp/test-image
 cosa fetch
 cosa build

--- a/docs/development/quickstart.md
+++ b/docs/development/quickstart.md
@@ -75,3 +75,11 @@ cosa build
 ```
 
 For more details, see `coreos-assembler` [overrides documentation](https://coreos.github.io/coreos-assembler/working/#using-overrides).
+
+### `build-fast` for faster iteration
+
+It is possible to use the CoreOS Assembler's [`build-fast`][build-fast-cmd] command for faster iteration.
+See [here][build-fast-instructions] for instructions on fast-building a qemu image for testing.
+
+[build-fast-cmd]: https://github.com/coreos/coreos-assembler/blob/master/src/cmd-build-fast
+[build-fast-instructions]: https://github.com/coreos/coreos-assembler/blob/2f834d37353ca5f40b460eae2aea73ef995bc710/docs/kola/external-tests.md#fast-build-and-iteration-on-your-projects-tests


### PR DESCRIPTION
We can just use for development the same image that CI in CoreOS projects use.