### PR TITLE
Clean up error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,28 +510,6 @@ dependencies = [
  "lazy_static",
  "log",
  "rand 0.7.3",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -1932,18 +1916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,18 +1949,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2521,12 +2493,12 @@ name = "zincati"
 version = "0.0.20-alpha.0"
 dependencies = [
  "actix",
+ "anyhow",
  "cfg-if 1.0.0",
  "chrono",
  "env_logger",
  "envsubst",
  "fail",
- "failure",
  "filetime",
  "futures",
  "glob",
@@ -2550,6 +2522,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tempfile",
+ "thiserror",
  "tokio",
  "toml",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fn-error-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac0b92c51c8b8183a0c101a7b2ea5fac11d2f1e01057f91e390284c75d76ef44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2500,6 +2511,7 @@ dependencies = [
  "envsubst",
  "fail",
  "filetime",
+ "fn-error-context",
  "futures",
  "glob",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,14 @@ edition = "2018"
 
 [dependencies]
 actix = "0.10"
+anyhow = "1.0"
 cfg-if = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 env_logger = "0.8"
 envsubst = "0.2"
 fail = "0.4"
-failure = "0.1"
 filetime = "0.2"
+fn-error-context = "0.1"
 futures = "0.3"
 glob = "0.3"
 intervaltree = "0.2.6"
@@ -35,8 +36,9 @@ regex = "1.4"
 reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tempfile = "^3.2"
 structopt = "0.3"
+tempfile = "^3.2"
+thiserror = "1.0"
 tokio = "0.2"
 toml = "0.5"
 url = { version = "2.2", features = ["serde"] }

--- a/src/cincinnati/client.rs
+++ b/src/cincinnati/client.rs
@@ -6,12 +6,13 @@
 
 // TODO(lucab): eventually move to its own "cincinnati client library" crate
 
-use failure::{Fail, Fallible, ResultExt};
+use anyhow::{Context, Result};
 use futures::prelude::*;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::Duration;
+use thiserror::Error;
 
 /// Default timeout for HTTP requests completion (30 minutes).
 const DEFAULT_HTTP_COMPLETION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
@@ -44,7 +45,7 @@ pub struct GraphJSONError {
 }
 
 /// Error related to the Cincinnati service.
-#[derive(Clone, Debug, Fail, PartialEq, Eq)]
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum CincinnatiError {
     /// Graph endpoint error.
     Graph(reqwest::StatusCode, GraphJSONError),
@@ -140,7 +141,7 @@ impl Client {
         &self,
         method: reqwest::Method,
         url_suffix: S,
-    ) -> Fallible<reqwest::RequestBuilder> {
+    ) -> Result<reqwest::RequestBuilder> {
         let url = self.api_base.clone().join(url_suffix.as_ref())?;
         let builder = self
             .hclient
@@ -202,7 +203,7 @@ impl ClientBuilder {
     }
 
     /// Build a client with specified parameters.
-    pub fn build(self) -> Fallible<Client> {
+    pub fn build(self) -> Result<Client> {
         let hclient = match self.hclient {
             Some(client) => client,
             None => reqwest::ClientBuilder::new()

--- a/src/cincinnati/mod.rs
+++ b/src/cincinnati/mod.rs
@@ -11,6 +11,7 @@ use crate::config::inputs;
 use crate::identity::Identity;
 use crate::rpm_ostree::Release;
 use anyhow::{Context, Result};
+use fn_error_context::context;
 use futures::prelude::*;
 use futures::TryFutureExt;
 use prometheus::{IntCounter, IntCounterVec, IntGauge};
@@ -105,6 +106,7 @@ pub struct Cincinnati {
 
 impl Cincinnati {
     /// Process Cincinnati configuration.
+    #[context("failed to validate cincinnati configuration")]
     pub(crate) fn with_config(cfg: inputs::CincinnatiInput, id: &Identity) -> Result<Self> {
         if cfg.base_url.is_empty() {
             anyhow::bail!("empty Cincinnati base URL");

--- a/src/cincinnati/mod.rs
+++ b/src/cincinnati/mod.rs
@@ -10,7 +10,7 @@ mod mock_tests;
 use crate::config::inputs;
 use crate::identity::Identity;
 use crate::rpm_ostree::Release;
-use failure::{bail, Fallible, ResultExt};
+use anyhow::{Context, Result};
 use futures::prelude::*;
 use futures::TryFutureExt;
 use prometheus::{IntCounter, IntCounterVec, IntGauge};
@@ -105,9 +105,9 @@ pub struct Cincinnati {
 
 impl Cincinnati {
     /// Process Cincinnati configuration.
-    pub(crate) fn with_config(cfg: inputs::CincinnatiInput, id: &Identity) -> Fallible<Self> {
+    pub(crate) fn with_config(cfg: inputs::CincinnatiInput, id: &Identity) -> Result<Self> {
         if cfg.base_url.is_empty() {
-            bail!("empty Cincinnati base URL");
+            anyhow::bail!("empty Cincinnati base URL");
         }
 
         // Substitute templated key with agent runtime values.
@@ -171,7 +171,7 @@ impl Cincinnati {
 
 /// Evaluate and record whether booted OS is a dead-end release, and
 /// log that information in a MOTD file.
-fn refresh_deadend_status(node: &Node) -> failure::Fallible<()> {
+fn refresh_deadend_status(node: &Node) -> Result<()> {
     match evaluate_deadend(node) {
         Some(reason) => {
             BOOTED_DEADEND.set(1);
@@ -184,7 +184,7 @@ fn refresh_deadend_status(node: &Node) -> failure::Fallible<()> {
                     .arg("--reason")
                     .arg(reason)
                     .output()
-                    .with_context(|_| "failed to write dead-end release information")?;
+                    .context("failed to write dead-end release information")?;
                 DEADEND_STATE.set_deadend();
                 log::debug!("MOTD updated with dead-end state");
             }
@@ -198,7 +198,7 @@ fn refresh_deadend_status(node: &Node) -> failure::Fallible<()> {
                     .arg("deadend-motd")
                     .arg("unset")
                     .output()
-                    .with_context(|_| "failed to remove dead-end release MOTD file")?;
+                    .context("failed to remove dead-end release MOTD file")?;
                 DEADEND_STATE.set_no_deadend();
                 log::debug!("MOTD updated with no dead-end state");
             }

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -3,7 +3,7 @@
 use super::ensure_user;
 use crate::{config, dbus, metrics, rpm_ostree, update_agent};
 use actix::Actor;
-use failure::{Fallible, ResultExt};
+use anyhow::{Context, Result};
 use log::{info, trace};
 use prometheus::IntGauge;
 use structopt::clap::{crate_name, crate_version};
@@ -16,7 +16,7 @@ lazy_static::lazy_static! {
 }
 
 /// Agent subcommand entry-point.
-pub(crate) fn run_agent() -> Fallible<()> {
+pub(crate) fn run_agent() -> Result<()> {
     ensure_user("zincati", "update agent not running as `zincati` user")?;
     info!(
         "starting update agent ({} {})",

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -24,8 +24,7 @@ pub(crate) fn run_agent() -> Result<()> {
         crate_version!()
     );
 
-    let settings =
-        config::Settings::assemble().context("failed to assemble configuration settings")?;
+    let settings = config::Settings::assemble()?;
     settings.refresh_metrics();
     info!(
         "agent running on node '{}', in update group '{}'",

--- a/src/cli/deadend.rs
+++ b/src/cli/deadend.rs
@@ -2,6 +2,7 @@
 
 use super::ensure_user;
 use anyhow::{Context, Result};
+use fn_error_context::context;
 use std::fs::Permissions;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
@@ -28,6 +29,7 @@ pub enum Cmd {
 
 impl Cmd {
     /// `deadend-motd` subcommand entry point.
+    #[context("failed to run `deadend-motd` subcommand")]
     pub(crate) fn run(self) -> Result<()> {
         ensure_user(
             "root",

--- a/src/cli/ex.rs
+++ b/src/cli/ex.rs
@@ -1,7 +1,7 @@
 //! Logic for the ex subcommand.
 
 use super::ensure_user;
-use failure::Fallible;
+use anyhow::Result;
 use structopt::StructOpt;
 use zbus::dbus_proxy;
 
@@ -21,7 +21,7 @@ pub enum Cmd {
 
 impl Cmd {
     /// `ex` subcommand entry point.
-    pub(crate) fn run(self) -> Fallible<()> {
+    pub(crate) fn run(self) -> Result<()> {
         ensure_user(
             "root",
             "ex subcommand must be run as `root` user, \

--- a/src/cli/ex.rs
+++ b/src/cli/ex.rs
@@ -2,6 +2,7 @@
 
 use super::ensure_user;
 use anyhow::Result;
+use fn_error_context::context;
 use structopt::StructOpt;
 use zbus::dbus_proxy;
 
@@ -21,6 +22,7 @@ pub enum Cmd {
 
 impl Cmd {
     /// `ex` subcommand entry point.
+    #[context("failed to run `ex` subcommand")]
     pub(crate) fn run(self) -> Result<()> {
         ensure_user(
             "root",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@ mod agent;
 mod deadend;
 mod ex;
 
+use anyhow::Result;
 use log::LevelFilter;
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
@@ -33,7 +34,7 @@ impl CliOptions {
     }
 
     /// Dispatch CLI subcommand.
-    pub(crate) fn run(self) -> failure::Fallible<()> {
+    pub(crate) fn run(self) -> Result<()> {
         match self.cmd {
             CliCommand::Agent => agent::run_agent(),
             CliCommand::DeadendMotd(cmd) => cmd.run(),
@@ -57,12 +58,12 @@ pub(crate) enum CliCommand {
 }
 
 /// Return Error with msg if not run by user.
-fn ensure_user(user: &str, msg: &str) -> failure::Fallible<()> {
+fn ensure_user(user: &str, msg: &str) -> Result<()> {
     if let Some(uname) = get_current_username() {
         if uname == user {
             return Ok(());
         }
     }
 
-    failure::bail!("{}", msg)
+    anyhow::bail!("{}", msg)
 }

--- a/src/config/inputs.rs
+++ b/src/config/inputs.rs
@@ -1,6 +1,6 @@
 use crate::config::fragments;
 use crate::update_agent::DEFAULT_STEADY_INTERVAL_SECS;
-use failure::{Fallible, ResultExt};
+use anyhow::{Context, Result};
 use log::trace;
 use ordered_float::NotNan;
 use serde::Serialize;
@@ -21,7 +21,7 @@ impl ConfigInput {
         dirs: Vec<String>,
         common_path: &str,
         extensions: Vec<String>,
-    ) -> Fallible<Self> {
+    ) -> Result<Self> {
         use std::io::Read;
 
         let scanner = liboverdrop::FragmentScanner::new(dirs, common_path, true, extensions);
@@ -31,12 +31,12 @@ impl ConfigInput {
             trace!("reading config fragment '{}'", fpath.display());
 
             let fp = std::fs::File::open(&fpath)
-                .context(format!("failed to open file '{}'", fpath.display()))?;
+                .with_context(|| format!("failed to open file '{}'", fpath.display()))?;
             let mut bufrd = std::io::BufReader::new(fp);
             let mut content = vec![];
             bufrd
                 .read_to_end(&mut content)
-                .context(format!("failed to read content of '{}'", fpath.display()))?;
+                .with_context(|| format!("failed to read content of '{}'", fpath.display()))?;
             let frag: fragments::ConfigFragment =
                 toml::from_slice(&content).context("failed to parse TOML")?;
 

--- a/src/config/inputs.rs
+++ b/src/config/inputs.rs
@@ -1,6 +1,7 @@
 use crate::config::fragments;
 use crate::update_agent::DEFAULT_STEADY_INTERVAL_SECS;
 use anyhow::{Context, Result};
+use fn_error_context::context;
 use log::trace;
 use ordered_float::NotNan;
 use serde::Serialize;
@@ -17,6 +18,7 @@ pub(crate) struct ConfigInput {
 
 impl ConfigInput {
     /// Read config fragments and merge them into a single config.
+    #[context("failed to read and merge config fragments")]
     pub(crate) fn read_configs(
         dirs: Vec<String>,
         common_path: &str,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,7 +15,7 @@ use crate::cincinnati::Cincinnati;
 use crate::identity::Identity;
 use crate::strategy::UpdateStrategy;
 use crate::update_agent;
-use failure::{Fallible, ResultExt};
+use anyhow::{Context, Result};
 use serde::Serialize;
 use std::num::NonZeroU64;
 use structopt::clap::crate_name;
@@ -41,7 +41,7 @@ pub(crate) struct Settings {
 
 impl Settings {
     /// Assemble runtime settings.
-    pub(crate) fn assemble() -> Fallible<Self> {
+    pub(crate) fn assemble() -> Result<Self> {
         let prefixes = vec![
             "/usr/lib/".to_string(),
             "/run/".to_string(),
@@ -63,7 +63,7 @@ impl Settings {
     }
 
     /// Validate config and return a valid agent settings.
-    fn validate(cfg: inputs::ConfigInput) -> Fallible<Self> {
+    fn validate(cfg: inputs::ConfigInput) -> Result<Self> {
         let allow_downgrade = cfg.updates.allow_downgrade;
         let enabled = cfg.updates.enabled;
         let steady_interval_secs = cfg.agent.steady_interval_secs;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,7 +15,8 @@ use crate::cincinnati::Cincinnati;
 use crate::identity::Identity;
 use crate::strategy::UpdateStrategy;
 use crate::update_agent;
-use anyhow::{Context, Result};
+use anyhow::Result;
+use fn_error_context::context;
 use serde::Serialize;
 use std::num::NonZeroU64;
 use structopt::clap::crate_name;
@@ -41,6 +42,7 @@ pub(crate) struct Settings {
 
 impl Settings {
     /// Assemble runtime settings.
+    #[context("failed to assemble configuration settings")]
     pub(crate) fn assemble() -> Result<Self> {
         let prefixes = vec![
             "/usr/lib/".to_string(),
@@ -67,12 +69,9 @@ impl Settings {
         let allow_downgrade = cfg.updates.allow_downgrade;
         let enabled = cfg.updates.enabled;
         let steady_interval_secs = cfg.agent.steady_interval_secs;
-        let identity = Identity::with_config(cfg.identity)
-            .context("failed to validate agent identity configuration")?;
-        let strategy = UpdateStrategy::with_config(cfg.updates, &identity)
-            .context("failed to validate update-strategy configuration")?;
-        let cincinnati = Cincinnati::with_config(cfg.cincinnati, &identity)
-            .context("failed to validate cincinnati configuration")?;
+        let identity = Identity::with_config(cfg.identity)?;
+        let strategy = UpdateStrategy::with_config(cfg.updates, &identity)?;
+        let cincinnati = Cincinnati::with_config(cfg.cincinnati, &identity)?;
 
         Ok(Self {
             allow_downgrade,

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -6,8 +6,8 @@ use experimental::Experimental;
 use crate::update_agent::UpdateAgent;
 use actix::prelude::*;
 use actix::Addr;
+use anyhow::Result;
 use core::convert::TryFrom;
-use failure::Error;
 use log::trace;
 use zbus::fdo;
 use zvariant::ObjectPath;
@@ -27,7 +27,7 @@ impl DBusService {
         SyncArbiter::start(threads, move || DBusService::new(agent_addr.clone()))
     }
 
-    fn start_object_server(&mut self) -> Result<(), Error> {
+    fn start_object_server(&mut self) -> Result<()> {
         let connection = zbus::Connection::new_system()?;
 
         fdo::DBusProxy::new(&connection)?.request_name(

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -8,6 +8,7 @@ use actix::prelude::*;
 use actix::Addr;
 use anyhow::Result;
 use core::convert::TryFrom;
+use fn_error_context::context;
 use log::trace;
 use zbus::fdo;
 use zvariant::ObjectPath;
@@ -27,6 +28,7 @@ impl DBusService {
         SyncArbiter::start(threads, move || DBusService::new(agent_addr.clone()))
     }
 
+    #[context("failed to start object server")]
     fn start_object_server(&mut self) -> Result<()> {
         let connection = zbus::Connection::new_system()?;
 

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -3,6 +3,7 @@ mod platform;
 use crate::config::inputs;
 use crate::rpm_ostree;
 use anyhow::{anyhow, ensure, Context, Result};
+use fn_error_context::context;
 use lazy_static::lazy_static;
 use libsystemd::id128;
 use ordered_float::NotNan;
@@ -52,6 +53,7 @@ pub(crate) struct Identity {
 
 impl Identity {
     /// Create from configuration.
+    #[context("failed to validate agent identity configuration")]
     pub(crate) fn with_config(cfg: inputs::IdentityInput) -> Result<Self> {
         let mut id = Self::try_default().context("failed to build default identity")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,8 +62,8 @@ fn run() -> i32 {
 }
 
 /// Pretty-print a chain of errors, as a series of error-priority log messages.
-fn log_error_chain(err_chain: failure::Error) {
-    let mut chain_iter = err_chain.iter_chain();
+fn log_error_chain(err_chain: anyhow::Error) {
+    let mut chain_iter = err_chain.chain();
     let top_err = match chain_iter.next() {
         Some(e) => e.to_string(),
         None => "(unspecified failure)".to_string(),

--- a/src/rpm_ostree/actor.rs
+++ b/src/rpm_ostree/actor.rs
@@ -3,7 +3,7 @@
 use super::cli_status::StatusJSON;
 use super::Release;
 use actix::prelude::*;
-use failure::Fallible;
+use anyhow::Result;
 use filetime::FileTime;
 use log::trace;
 use std::collections::BTreeSet;
@@ -45,11 +45,11 @@ pub struct StageDeployment {
 }
 
 impl Message for StageDeployment {
-    type Result = Fallible<Release>;
+    type Result = Result<Release>;
 }
 
 impl Handler<StageDeployment> for RpmOstreeClient {
-    type Result = Fallible<Release>;
+    type Result = Result<Release>;
 
     fn handle(&mut self, msg: StageDeployment, _ctx: &mut Self::Context) -> Self::Result {
         trace!("request to stage release: {:?}", msg.release);
@@ -65,11 +65,11 @@ pub struct FinalizeDeployment {
 }
 
 impl Message for FinalizeDeployment {
-    type Result = Fallible<Release>;
+    type Result = Result<Release>;
 }
 
 impl Handler<FinalizeDeployment> for RpmOstreeClient {
-    type Result = Fallible<Release>;
+    type Result = Result<Release>;
 
     fn handle(&mut self, msg: FinalizeDeployment, _ctx: &mut Self::Context) -> Self::Result {
         trace!("request to finalize release: {:?}", msg.release);
@@ -85,11 +85,11 @@ pub struct QueryLocalDeployments {
 }
 
 impl Message for QueryLocalDeployments {
-    type Result = Fallible<BTreeSet<Release>>;
+    type Result = Result<BTreeSet<Release>>;
 }
 
 impl Handler<QueryLocalDeployments> for RpmOstreeClient {
-    type Result = Fallible<BTreeSet<Release>>;
+    type Result = Result<BTreeSet<Release>>;
 
     fn handle(
         &mut self,
@@ -106,11 +106,11 @@ impl Handler<QueryLocalDeployments> for RpmOstreeClient {
 pub struct RegisterAsDriver {}
 
 impl Message for RegisterAsDriver {
-    type Result = Fallible<()>;
+    type Result = Result<()>;
 }
 
 impl Handler<RegisterAsDriver> for RpmOstreeClient {
-    type Result = Fallible<()>;
+    type Result = Result<()>;
 
     fn handle(&mut self, _msg: RegisterAsDriver, _ctx: &mut Self::Context) -> Self::Result {
         trace!("request to register as rpm-ostree update driver");

--- a/src/rpm_ostree/mod.rs
+++ b/src/rpm_ostree/mod.rs
@@ -12,7 +12,7 @@ pub use actor::{
 mod mock_tests;
 
 use crate::cincinnati::{Node, AGE_INDEX_KEY, CHECKSUM_SCHEME, SCHEME_KEY};
-use failure::{ensure, format_err, Fallible, ResultExt};
+use anyhow::{anyhow, ensure, Context, Result};
 use serde::Serialize;
 use std::cmp::Ordering;
 
@@ -58,13 +58,13 @@ impl std::cmp::PartialOrd for Release {
 
 impl Release {
     /// Builds a `Release` object from a Cincinnati node.
-    pub fn from_cincinnati(node: Node) -> Fallible<Self> {
+    pub fn from_cincinnati(node: Node) -> Result<Self> {
         ensure!(!node.version.is_empty(), "empty version field");
         ensure!(!node.payload.is_empty(), "empty payload field (checksum)");
         let scheme = node
             .metadata
             .get(SCHEME_KEY)
-            .ok_or_else(|| format_err!("missing metadata key: {}", SCHEME_KEY))?;
+            .ok_or_else(|| anyhow!("missing metadata key: {}", SCHEME_KEY))?;
 
         ensure!(
             scheme == CHECKSUM_SCHEME,
@@ -76,7 +76,7 @@ impl Release {
             let val = node
                 .metadata
                 .get(AGE_INDEX_KEY)
-                .ok_or_else(|| format_err!("missing metadata key: {}", AGE_INDEX_KEY))?;
+                .ok_or_else(|| anyhow!("missing metadata key: {}", AGE_INDEX_KEY))?;
 
             val.parse::<u64>()
                 .context(format!("invalid age_index value: {}", val))?

--- a/src/strategy/immediate.rs
+++ b/src/strategy/immediate.rs
@@ -1,6 +1,6 @@
 //! Strategy for immediate updates.
 
-use failure::Error;
+use anyhow::Error;
 use futures::future;
 use futures::prelude::*;
 use log::trace;

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -3,6 +3,7 @@
 use crate::config::inputs;
 use crate::identity::Identity;
 use anyhow::Result;
+use fn_error_context::context;
 use futures::prelude::*;
 use log::error;
 use prometheus::{IntGauge, IntGaugeVec};
@@ -39,6 +40,7 @@ pub(crate) enum UpdateStrategy {
 
 impl UpdateStrategy {
     /// Try to parse config inputs into a valid strategy.
+    #[context("failed to validate update strategy configuration")]
     pub(crate) fn with_config(cfg: inputs::UpdateInput, identity: &Identity) -> Result<Self> {
         let strategy_name = cfg.strategy.clone();
         let strategy = match strategy_name.as_ref() {

--- a/src/strategy/periodic.rs
+++ b/src/strategy/periodic.rs
@@ -3,6 +3,7 @@
 use crate::config::inputs;
 use crate::weekly::{utils, WeeklyCalendar, WeeklyWindow};
 use anyhow::{Error, Result};
+use fn_error_context::context;
 use futures::future;
 use futures::prelude::*;
 use log::trace;
@@ -22,6 +23,7 @@ impl StrategyPeriodic {
     pub const LABEL: &'static str = "periodic";
 
     /// Build a new periodic strategy.
+    #[context("failed to parse periodic strategy")]
     pub fn new(cfg: inputs::UpdateInput) -> Result<Self> {
         let mut intervals = Vec::with_capacity(cfg.periodic.intervals.len());
 

--- a/src/strategy/periodic.rs
+++ b/src/strategy/periodic.rs
@@ -2,7 +2,7 @@
 
 use crate::config::inputs;
 use crate::weekly::{utils, WeeklyCalendar, WeeklyWindow};
-use failure::{Error, Fallible};
+use anyhow::{Error, Result};
 use futures::future;
 use futures::prelude::*;
 use log::trace;
@@ -22,7 +22,7 @@ impl StrategyPeriodic {
     pub const LABEL: &'static str = "periodic";
 
     /// Build a new periodic strategy.
-    pub fn new(cfg: inputs::UpdateInput) -> Fallible<Self> {
+    pub fn new(cfg: inputs::UpdateInput) -> Result<Self> {
         let mut intervals = Vec::with_capacity(cfg.periodic.intervals.len());
 
         for entry in cfg.periodic.intervals {
@@ -35,7 +35,7 @@ impl StrategyPeriodic {
 
         let calendar = WeeklyCalendar::new(intervals);
         match calendar.length_minutes() {
-            0 => failure::bail!(
+            0 => anyhow::bail!(
                 "invalid or missing periodic updates configuration: weekly calendar length is zero"
             ),
             n => log::trace!("periodic updates, weekly calendar length: {} minutes", n),

--- a/src/update_agent/actor.rs
+++ b/src/update_agent/actor.rs
@@ -3,7 +3,7 @@
 use super::{UpdateAgent, UpdateAgentState};
 use crate::rpm_ostree::{self, Release};
 use actix::prelude::*;
-use failure::Error;
+use anyhow::Error;
 use futures::prelude::*;
 use libsystemd::daemon::*;
 use log::trace;

--- a/src/weekly/mod.rs
+++ b/src/weekly/mod.rs
@@ -8,8 +8,8 @@
 
 pub(crate) mod utils;
 
+use anyhow::{ensure, Result};
 use chrono::{DateTime, Utc};
-use failure::Fallible;
 use intervaltree::{Element, IntervalTree};
 use serde::{Serialize, Serializer};
 use std::cmp::Ordering;
@@ -91,7 +91,7 @@ impl WeeklyCalendar {
     }
 
     /// Format remaining duration till the next window in human terms.
-    pub fn human_remaining_duration(remaining: &chrono::Duration) -> Fallible<String> {
+    pub fn human_remaining_duration(remaining: &chrono::Duration) -> Result<String> {
         if remaining.is_zero() {
             return Ok("now".to_string());
         }
@@ -220,9 +220,9 @@ impl WeeklyWindow {
         start_hour: u8,
         start_minute: u8,
         length: Duration,
-    ) -> Fallible<Vec<Self>> {
+    ) -> Result<Vec<Self>> {
         // Sanity check inputs (start and length).
-        failure::ensure!(
+        ensure!(
             start_hour <= 24 && start_minute <= 59,
             "invalid start time: {}:{}",
             start_hour,

--- a/src/weekly/mod.rs
+++ b/src/weekly/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod utils;
 
 use anyhow::{ensure, Result};
 use chrono::{DateTime, Utc};
+use fn_error_context::context;
 use intervaltree::{Element, IntervalTree};
 use serde::{Serialize, Serializer};
 use std::cmp::Ordering;
@@ -215,6 +216,7 @@ impl WeeklyWindow {
     /// Parse a timespan into weekly windows.
     ///
     /// On success, this returns a non-empty vector with at most two weekly windows.
+    #[context("failed to parse timespan into weekly windows")]
     pub fn parse_timespan(
         start_day: chrono::Weekday,
         start_hour: u8,

--- a/src/weekly/utils.rs
+++ b/src/weekly/utils.rs
@@ -3,6 +3,7 @@
 use crate::weekly::{MinuteInWeek, MAX_WEEKLY_MINS, MAX_WEEKLY_SECS};
 use anyhow::{anyhow, bail, ensure, Result};
 use chrono::{DateTime, Utc, Weekday};
+use fn_error_context::context;
 use std::time::Duration;
 
 /// Convert datetime to minutes since beginning of week.
@@ -74,6 +75,7 @@ pub(crate) fn weekday_from_string(input: &str) -> Result<Weekday> {
 /// assert_eq!(morning.0, 14);
 /// assert_eq!(morning.0, 5);
 /// ```
+#[context("failed to parse time string")]
 pub(crate) fn time_from_string(input: &str) -> Result<(u8, u8)> {
     let fields: Vec<_> = input.split(':').collect();
     if fields.len() != 2 {

--- a/src/weekly/utils.rs
+++ b/src/weekly/utils.rs
@@ -1,8 +1,8 @@
 //! Utilities for weekly-time related logic.
 
 use crate::weekly::{MinuteInWeek, MAX_WEEKLY_MINS, MAX_WEEKLY_SECS};
+use anyhow::{anyhow, bail, ensure, Result};
 use chrono::{DateTime, Utc, Weekday};
-use failure::{bail, ensure, format_err, Fallible};
 use std::time::Duration;
 
 /// Convert datetime to minutes since beginning of week.
@@ -34,19 +34,19 @@ pub(crate) fn time_as_weekly_minute(day: chrono::Weekday, hour: u8, minute: u8) 
 }
 
 /// Check duration for a sane lower and upper bound (whole week).
-pub(crate) fn check_duration(length: &Duration) -> Fallible<()> {
+pub(crate) fn check_duration(length: &Duration) -> Result<()> {
     if length.as_secs() > MAX_WEEKLY_SECS {
-        failure::bail!("length longer than a week")
+        bail!("length longer than a week")
     };
     if length.as_secs() == 0 {
-        failure::bail!("zero-length duration")
+        bail!("zero-length duration")
     };
 
     Ok(())
 }
 
 /// Parse a week day string (English names).
-pub(crate) fn weekday_from_string(input: &str) -> Fallible<Weekday> {
+pub(crate) fn weekday_from_string(input: &str) -> Result<Weekday> {
     let day = match input.to_lowercase().as_str() {
         "mon" | "monday" => Weekday::Mon,
         "tue" | "tuesady" => Weekday::Tue,
@@ -74,7 +74,7 @@ pub(crate) fn weekday_from_string(input: &str) -> Fallible<Weekday> {
 /// assert_eq!(morning.0, 14);
 /// assert_eq!(morning.0, 5);
 /// ```
-pub(crate) fn time_from_string(input: &str) -> Fallible<(u8, u8)> {
+pub(crate) fn time_from_string(input: &str) -> Result<(u8, u8)> {
     let fields: Vec<_> = input.split(':').collect();
     if fields.len() != 2 {
         bail!("unrecognized time value: {}", input);
@@ -82,11 +82,11 @@ pub(crate) fn time_from_string(input: &str) -> Fallible<(u8, u8)> {
 
     let hour = fields[0]
         .parse()
-        .map_err(|_| format_err!("unrecognized time (hour) value: {}", input))?;
+        .map_err(|_| anyhow!("unrecognized time (hour) value: {}", input))?;
 
     let minute = fields[1]
         .parse()
-        .map_err(|_| format_err!("unrecognized time (minute) value: {}", input))?;
+        .map_err(|_| anyhow!("unrecognized time (minute) value: {}", input))?;
 
     ensure!(hour <= 23 && minute <= 59, "invalid time: {}", input);
     Ok((hour, minute))
@@ -94,7 +94,7 @@ pub(crate) fn time_from_string(input: &str) -> Fallible<(u8, u8)> {
 
 /// Validate a timespan (in minutes) and return its duration.
 #[cfg(test)]
-pub(crate) fn check_minutes(minutes: u32) -> Fallible<Duration> {
+pub(crate) fn check_minutes(minutes: u32) -> Result<Duration> {
     let secs = u64::from(minutes).saturating_mul(60);
     let length = Duration::from_secs(secs);
     check_duration(&length)?;


### PR DESCRIPTION
### Move from `failure` to `anyhow`

The `failure` library is now deprecated, use `anyhow` instead.

### Add and use `fn-error-context` for more reliable error traces:

Same motivation as https://github.com/coreos/bootupd/pull/163.

Effectively what we're doing here is creating a human-readable subset
of the stack trace. This is nicer than having the calling functions
add `with_context()` because it's more verbose (gets duplicative at
each call site), easy to forget, etc.

While we're at it, add some `fn-error-context`-style contexts to
functions whose callers forgot to or didn't add context.