### PR TITLE
Release 0.0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.20-alpha.0"
+version = "0.0.20"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.20"
+version = "0.0.21-alpha.0"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.20-alpha.0"
+version = "0.0.20"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.20"
+version = "0.0.21-alpha.0"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
 * strategy/periodic: support configuring a time zone for reboot windows
 * src: clean up error handling
 * agent: add new actor for D-Bus server interface
 * cargo: bump tokio, actix, reqwest
 * doc/quickstart: use FCOS buildroot image
 * docs: fix "Edit this page on GitHub" links
 * tests/kola: add dead-end MOTD kola test
 * ci: adapt to new buildroot image
 * ci: bump MSRV toolchain
 * ci: bump linting toolchain
 * ci: use fcos buildroot

Tracker: https://github.com/coreos/zincati/milestone/17