### PR TITLE
main: update systemd StatusText on SIGTERM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "1.0"
 structopt = "0.3"
 tempfile = "^3.2"
 thiserror = "1.0"
-tokio = { version = "1.5", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.5", features = ["signal", "rt", "rt-multi-thread"] }
 toml = "0.5"
 tzfile = "0.1.3"
 url = { version = "2.2", features = ["serde"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ mod rpm_ostree;
 mod strategy;
 /// Update agent.
 mod update_agent;
+/// Utility functions.
+mod utils;
 /// Logic for weekly maintenance windows.
 mod weekly;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,35 @@
+//! Miscellaneous utility functions.
+
+use libsystemd::daemon::{notify, NotifyState};
+
+/// Helper function to update unit's status text.
+pub(crate) fn update_unit_status(status: &str) {
+    sd_notify(&[NotifyState::Status(status.to_string())]);
+}
+
+/// Helper function to notify the service manager that Zincati start up is finished and
+/// configuration is loaded.
+pub(crate) fn notify_ready() {
+    sd_notify(&[NotifyState::Ready]);
+}
+
+/// Helper function to notify the service manager that Zincati is stopping.
+pub(crate) fn notify_stopping() {
+    sd_notify(&[NotifyState::Stopping]);
+}
+
+/// Helper function to send notifications to the service manager about service status changes.
+/// Log errors if unsuccessful.
+fn sd_notify(state: &[NotifyState]) {
+    match notify(false, state) {
+        Err(e) => log::error!(
+            "failed to notify service manager of service status change: {}",
+            e
+        ),
+        Ok(sent) => {
+            if !sent {
+                log::error!("status notifications not supported for this service");
+            }
+        }
+    }
+}

--- a/tests/kola/misc/test-status.sh
+++ b/tests/kola/misc/test-status.sh
@@ -32,6 +32,10 @@ do
     fi
     sleep 1
 done
-echo "timed out waiting for Zincati to check for updates"
 assert_file_has_content zincati_last_check_status.txt 'periodically polling for updates (last checked'
 ok "status show last check"
+
+systemctl stop zincati.service
+systemctl show -p StatusText zincati.service > zincati_stopped_status.txt
+assert_not_file_has_content zincati_stopped_status.txt '.+'
+ok "status show daemon stopped"


### PR DESCRIPTION
Currently, when we stop zincati.service, the systemd StatusText
remains as whatever it was before it was stopped. This is
somewhat misleading when the StatusText is shown in e.g.
`rpm-ostree status`.