### PR TITLE
Release 0.0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.21-alpha.0"
+version = "0.0.21"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.21"
+version = "0.0.22-alpha.0"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.21"
+version = "0.0.22-alpha.0"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.21-alpha.0"
+version = "0.0.21"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
- docs/usage/updates-strategy: use real emoji
- update_agent: fix logic around reboot delays
- agent: clear systemd StatusText on SIGTERM
- update_agent: reword reboot delay broadcast mesage
- rpm_ostree/actor: add traces when CLI returns
- cargo: development version bump
- update_agent: log deploy attempt outcome
- cargo/release: set sign-tag property

Tracker: https://github.com/coreos/zincati/milestone/18