### PR TITLE
dist: fix dbus configuration

### DIFF
--- a/dist/dbus-1/system.d/org.coreos.zincati.conf
+++ b/dist/dbus-1/system.d/org.coreos.zincati.conf
@@ -3,15 +3,27 @@
 <!DOCTYPE busconfig PUBLIC
           "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
           "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
-<busconfig>
 
-  <!-- Only user zincati can own the service -->
-  <policy user="zincati">
-    <allow own="org.coreos.zincati"/>
+<busconfig>
+  <!-- Generally allow access only for introspection -->
+  <policy context="default">
+    <allow send_destination="org.coreos.zincati"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="org.coreos.zincati"
+           send_interface="org.freedesktop.DBus.Peer"/>
+    <allow send_destination="org.coreos.zincati"
+           send_interface="org.freedesktop.DBus.Properties"/>
   </policy>
 
-  <!-- Only allow root to call into the service -->
-  <policy context="default" user="root">
+  <!-- User 'zincati' is the service owner -->
+  <policy user="zincati">
+    <allow own_prefix="org.coreos.zincati"/>
+    <allow send_destination="org.coreos.zincati"/>
+    <allow receive_sender="org.coreos.zincati"/>
+  </policy>
+
+  <!-- User 'root' is allowed to call into the service -->
+  <policy user="root">
     <allow send_destination="org.coreos.zincati"/>
     <allow receive_sender="org.coreos.zincati"/>
   </policy>


### PR DESCRIPTION
This tweaks dbus configuration, fixing some mistakes in the ACLs.
It gets rid of the following dbus-broker warning:
> Conflicting attributes in /usr/share/dbus-1/system.d/org.coreos.zincati.conf +14