### PR TITLE
update_agent: promote some log messages to INFO level

### DIFF
--- a/src/update_agent/actor.rs
+++ b/src/update_agent/actor.rs
@@ -242,7 +242,7 @@ impl UpdateAgent {
         let state_change =
             actix::fut::wrap_future::<_, Self>(report_steady).map(|is_steady, actor, _ctx| {
                 if is_steady {
-                    log::debug!("reached steady state, periodically polling for updates");
+                    log::info!("reached steady state, periodically polling for updates");
                     utils::update_unit_status("periodically polling for updates");
                     actor.state.reported_steady();
                 }
@@ -305,7 +305,7 @@ impl UpdateAgent {
                 Ok(_) => {
                     let msg = format!("update staged: {}", release.version);
                     utils::update_unit_status(&msg);
-                    log::trace!("{}", msg);
+                    log::info!("{}", msg);
                     actor.state.update_staged(release);
                 }
                 Err(_) => {


### PR DESCRIPTION
It should be safe to promote to INFO level the message that Zincati
has successfully staged a deployment and the message that Zincati has
reached its "steady" state, without the risk of being overly verbose.
This will help admins get a better idea of which
stage in the state machine Zincati is in.