### PR TITLE
update_agent: put state behind RwLock

### DIFF
--- a/src/cincinnati/mod.rs
+++ b/src/cincinnati/mod.rs
@@ -98,7 +98,7 @@ impl DeadEndState {
 }
 
 /// Cincinnati configuration.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct Cincinnati {
     /// Service base URL.
     pub base_url: String,

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -33,7 +33,7 @@ lazy_static::lazy_static! {
 }
 
 /// Agent identity.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub(crate) struct Identity {
     /// OS base architecture.
     pub(crate) basearch: String,


### PR DESCRIPTION
We would like to put update agent state behind a RwLock so ticks
can be handled sequentially while allowing messages to the
`update_agent` actor to be handled concurrently, in general.

Closes: https://github.com/coreos/zincati/issues/569