### PR TITLE
workflows: bump MSRV and lints toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,9 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.47.0
+  ACTION_MSRV_TOOLCHAIN: 1.53.0
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.51.0
+  ACTION_LINTS_TOOLCHAIN: 1.53.0
 
 jobs:
   tests-stable:

--- a/src/rpm_ostree/mod.rs
+++ b/src/rpm_ostree/mod.rs
@@ -30,8 +30,8 @@ pub struct Release {
 impl std::cmp::Ord for Release {
     fn cmp(&self, other: &Self) -> Ordering {
         // Order is primarily based on age-index coming from Cincinnati.
-        let self_age = self.age_index.clone().unwrap_or(0);
-        let other_age = other.age_index.clone().unwrap_or(0);
+        let self_age = self.age_index.unwrap_or(0);
+        let other_age = other.age_index.unwrap_or(0);
         if self_age != other_age {
             return self_age.cmp(&other_age);
         }

--- a/src/weekly/mod.rs
+++ b/src/weekly/mod.rs
@@ -15,7 +15,6 @@ use intervaltree::{Element, IntervalTree};
 use serde::{Serialize, Serializer};
 use std::cmp::Ordering;
 use std::fmt::Write;
-use std::iter::FromIterator;
 use std::ops::Range;
 use std::time::Duration;
 
@@ -43,7 +42,7 @@ impl WeeklyCalendar {
             .map(|win| Element::from((win.range_weekly_minutes(), win)));
 
         Self {
-            windows: IntervalTree::from_iter(intervals),
+            windows: intervals.collect(),
         }
     }
 


### PR DESCRIPTION
Fedora 34 (the base of FCOS in all release streams) is already on
1.53; bump MSRV to this, as well, since `zvariant` wants this.
Also bump the lints toolchain to the latest Rust version.