### PR TITLE
Release 0.0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.22"
+version = "0.0.23-alpha.0"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.22-alpha.0"
+version = "0.0.22"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.22-alpha.0"
+version = "0.0.22"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.22"
+version = "0.0.23-alpha.0"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
 * lockfile: general refresh, update all openssl crates
 * Add more metrics around finalization attempts
 * workflows: bump MSRV and lints toolchain
 * update_agent: promote some log messages to INFO level
 * update_agent: slow down end state tick cadence
 * dist: fix dbus configuration