### PR TITLE
update_agent: remove unused `Result`s

### DIFF
--- a/src/rpm_ostree/actor.rs
+++ b/src/rpm_ostree/actor.rs
@@ -112,11 +112,11 @@ impl Handler<QueryLocalDeployments> for RpmOstreeClient {
 pub struct RegisterAsDriver {}
 
 impl Message for RegisterAsDriver {
-    type Result = Result<()>;
+    type Result = ();
 }
 
 impl Handler<RegisterAsDriver> for RpmOstreeClient {
-    type Result = Result<()>;
+    type Result = ();
 
     fn handle(&mut self, _msg: RegisterAsDriver, _ctx: &mut Self::Context) -> Self::Result {
         trace!("request to register as rpm-ostree update driver");

--- a/src/rpm_ostree/cli_deploy.rs
+++ b/src/rpm_ostree/cli_deploy.rs
@@ -38,7 +38,7 @@ pub fn deploy_locked(release: Release, allow_downgrade: bool) -> Result<Release>
 /// Register as the update driver.
 /// Keep attempting to register as driver for rpm-ostree, with exponential backoff
 /// capped at 256 seconds.
-pub fn deploy_register_driver() -> Result<()> {
+pub fn deploy_register_driver() {
     let mut register_attempt = invoke_cli_register();
     let mut retry_secs = Duration::from_secs(1);
     while let Err(attempt) = register_attempt {
@@ -51,8 +51,6 @@ pub fn deploy_register_driver() -> Result<()> {
             retry_secs *= 2;
         }
     }
-
-    Ok(())
 }
 
 /// CLI executor for registering driver.
@@ -162,7 +160,7 @@ mod tests {
         let now = SystemTime::now();
         // expect to take 1 + 2 + 4 = 7 seconds
         // to register as driver due to `fail_point`s
-        deploy_register_driver().unwrap();
+        deploy_register_driver();
         let elapsed = now.elapsed().unwrap().as_secs();
         // `fail_point`s are set to succeed on 4th try
         assert!(REGISTER_DRIVER_FAILURES.get() == 3);

--- a/src/update_agent/actor.rs
+++ b/src/update_agent/actor.rs
@@ -4,7 +4,7 @@ use super::{UpdateAgent, UpdateAgentInfo, UpdateAgentState};
 use crate::rpm_ostree::{self, Release};
 use crate::utils;
 use actix::prelude::*;
-use anyhow::Error;
+use anyhow::{Error, Result};
 use futures::prelude::*;
 use log::trace;
 use prometheus::{IntCounter, IntCounterVec, IntGauge};
@@ -260,15 +260,12 @@ impl UpdateAgentInfo {
     async fn tick_initialize(&self, state: &mut UpdateAgentState) {
         trace!("update agent in start state");
         if self.enabled {
-            let register_outcome = self.register_as_driver().await;
-            if register_outcome.is_err() {
-                // In practice, we should not reach here: https://github.com/coreos/zincati/pull/599.
-                return;
-            };
+            self.register_as_driver().await;
         }
         let local_depls = self.local_deployments().await;
-        if let Ok(depls) = local_depls {
-            UpdateAgent::log_excluded_depls(&depls, &self);
+        match local_depls {
+            Ok(depls) => UpdateAgent::log_excluded_depls(&depls, &self),
+            Err(e) => log::error!("failed to query local deployments: {}", e),
         }
         let status;
         if self.enabled {
@@ -316,7 +313,10 @@ impl UpdateAgentInfo {
                     .fetch_update_hint(&self.identity, depls, allow_downgrade)
                     .await
             }
-            _ => None,
+            Err(e) => {
+                log::error!("failed to query local deployments: {}", e);
+                None
+            }
         };
 
         match release {
@@ -338,13 +338,14 @@ impl UpdateAgentInfo {
         let deploy_outcome = self.attempt_deploy(target).await;
 
         match deploy_outcome {
-            Ok(_) => {
+            Ok(release) => {
                 let msg = format!("update staged: {}", release.version);
                 utils::update_unit_status(&msg);
                 log::info!("{}", msg);
                 state.update_staged(release);
             }
-            Err(_) => {
+            Err(e) => {
+                log::error!("failed to stage deployment: {}", e);
                 let release_ver = release.version.clone();
                 let fail_count = UpdateAgentInfo::deploy_attempt_failed(release, &mut state);
                 let msg = format!(
@@ -373,24 +374,31 @@ impl UpdateAgentInfo {
             // Reset number of postponements to `MAX_FINALIZE_POSTPONEMENTS`
             // if strategy does not allow finalization.
             state.update_staged(release);
-        } else {
-            let usersessions_can_finalize = state.usersessions_can_finalize();
-            if !usersessions_can_finalize {
-                FINALIZATION_BLOCKED
-                    .with_label_values(&[ACTIVE_USERSESSIONS_LABEL])
-                    .inc();
-                utils::update_unit_status(&format!(
-                    "update staged: {}; reboot delayed due to active user sessions",
-                    release.version
-                ));
-                // Record postponement and postpone finalization.
-                state.record_postponement();
-            } else if let Ok(release) = self.finalize_deployment(release).await {
+            return;
+        }
+
+        let usersessions_can_finalize = state.usersessions_can_finalize();
+        if !usersessions_can_finalize {
+            FINALIZATION_BLOCKED
+                .with_label_values(&[ACTIVE_USERSESSIONS_LABEL])
+                .inc();
+            utils::update_unit_status(&format!(
+                "update staged: {}; reboot delayed due to active user sessions",
+                release.version
+            ));
+            // Record postponement and postpone finalization.
+            state.record_postponement();
+            return;
+        }
+
+        match self.finalize_deployment(release).await {
+            Ok(release) => {
                 FINALIZATION_SUCCESS.inc();
                 utils::update_unit_status(&format!("update finalized: {}", release.version));
                 state.update_finalized(release);
             }
-        };
+            Err(e) => log::error!("failed to finalize deployment: {}", e),
+        }
     }
 
     /// Actor job is done.
@@ -402,7 +410,7 @@ impl UpdateAgentInfo {
     }
 
     /// Fetch and stage an update, in finalization-locked mode.
-    async fn attempt_deploy(&self, release: Release) -> Result<Release, ()> {
+    async fn attempt_deploy(&self, release: Release) -> Result<Release> {
         log::info!(
             "target release '{}' selected, proceeding to stage it",
             release.version
@@ -415,7 +423,6 @@ impl UpdateAgentInfo {
             .rpm_ostree_actor
             .send(msg)
             .unwrap_or_else(|e| Err(e.into()))
-            .map_err(|e| log::error!("failed to stage deployment: {}", e))
             .await;
 
         upgrade
@@ -438,13 +445,12 @@ impl UpdateAgentInfo {
     ///
     /// This ignores deployments that have been only staged but not finalized in the
     /// past, as they are acceptable as future update target.
-    async fn local_deployments(&self) -> Result<BTreeSet<Release>, ()> {
+    async fn local_deployments(&self) -> Result<BTreeSet<Release>> {
         let msg = rpm_ostree::QueryLocalDeployments { omit_staged: true };
         let depls = self
             .rpm_ostree_actor
             .send(msg)
             .unwrap_or_else(|e| Err(e.into()))
-            .map_err(|e| log::error!("failed to query local deployments: {}", e))
             .map_ok(move |depls| {
                 log::trace!("found {} local deployments", depls.len());
                 depls
@@ -455,7 +461,7 @@ impl UpdateAgentInfo {
     }
 
     /// Finalize a deployment (unlock and reboot).
-    async fn finalize_deployment(&self, release: Release) -> Result<Release, ()> {
+    async fn finalize_deployment(&self, release: Release) -> Result<Release> {
         log::info!(
             "staged deployment '{}' available, proceeding to finalize it",
             release.version
@@ -466,25 +472,20 @@ impl UpdateAgentInfo {
             .rpm_ostree_actor
             .send(msg)
             .unwrap_or_else(|e| Err(e.into()))
-            .map_err(|e| log::error!("failed to finalize deployment: {}", e))
             .await;
 
         upgrade
     }
 
     /// Attempt to register as the update driver for rpm-ostree.
-    async fn register_as_driver(&self) -> Result<(), ()> {
+    async fn register_as_driver(&self) {
         log::info!("registering as the update driver for rpm-ostree");
 
         let msg = rpm_ostree::RegisterAsDriver {};
-        let result = self
-            .rpm_ostree_actor
+        self.rpm_ostree_actor
             .send(msg)
-            .unwrap_or_else(|e| Err(e.into()))
-            .map_err(|e| log::error!("failed to register as driver: {}", e))
-            .await;
-
-        result
+            .unwrap_or_else(|e| log::error!("failed to register as driver: {}", e))
+            .await
     }
 }
 


### PR DESCRIPTION
### update_agent: remove unused `Result`s

Previously, the `tick_` functions returned a `Result`, but only two
of these functions would ever return the `Err` variant. Even in the
case where the returned `Result` was of the `Err` variant, the caller
does not really do anything with it.

Since we already do a good amount of error logging in the inner
functions, refactor the `tick_` functions to return `()` instead.

### update_agent: misc cleanup
For helpers that return a `Result`, move error logging to the caller
functions.

Refactor `register_driver` to return `()`, because errors shouldn't
be returned since https://github.com/coreos/zincati/pull/599.

Use `anyhow::Result`.

Refactor `tick_finalize_update` to return early to avoid deeply nested
if-else statements.