### PR TITLE
update_agent: use `Cell` for `state_changed` field

### DIFF
--- a/src/update_agent/actor.rs
+++ b/src/update_agent/actor.rs
@@ -135,10 +135,9 @@ impl Handler<RefreshTick> for UpdateAgent {
 
             // Update state_changed timestamp if necessary.
             if discriminant(&prev_state) != discriminant(&*agent_state_guard) {
-                let cur_timestamp = chrono::Utc::now();
-                // This mutable borrow will not panic because we are still holding
-                // the UpdateAgentState's `RwLock` for writing.
-                *last_changed.borrow_mut() = cur_timestamp;
+                // In practice, this field will be monotonically increasing as we
+                // ensure that we only set it when a `RwLock` to state is acquired.
+                last_changed.set(chrono::Utc::now());
             }
 
             Self::refresh_delay(


### PR DESCRIPTION
The previous incorrect usage of `RefCell` allowed for panics at runtime
if there were consumers.
`Cell` should be sufficient here, since the data that we are storing
is a simple timestamp (easily `Copy`-able). We do not need to use an atomic type because the
update_agent actor runs on a single thread on the SystemArbiter.

Ref: https://github.com/coreos/zincati/pull/614#discussion_r679747046