### PR TITLE
Release 0.0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.23-alpha.0"
+version = "0.0.23"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.23"
+version = "0.0.24-alpha.0"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.23-alpha.0"
+version = "0.0.23"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.23"
+version = "0.0.24-alpha.0"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
- workflows: limit permissions to reading repo contents
- rpm_ostree/deploy: block on driver registration
- docs/images: update actor graph with D-Bus actor
- update_agent: put agent state behind a RwLock
- update_agent: remove unused `Result`s
- update_agent: misc cleanup
- update_agent: put state behind `Rc` instead of `Arc`
- update_agent: split state_changed out of UpdateAgentInfo
- update_agent: use `Cell` for `state_changed` field
- dist/config.d/*.toml: Add missing EOL