### PR TITLE
update_agent: improve linewrapping of logout warning

### DIFF
--- a/src/update_agent/mod.rs
+++ b/src/update_agent/mod.rs
@@ -506,9 +506,10 @@ fn format_reboot_warning(seconds: u64, release_ver: &str) -> String {
 
     format!(
         "New update {} is available and has been deployed.\n\
-        If permitted by the update strategy, Zincati will reboot into this update when all\n\
-        interactive users have logged out, or in {}, whichever comes earlier.\n\
-        Please log out of all active sessions in order to let the auto-update process continue.",
+        If permitted by the update strategy, Zincati will reboot into this update when\n\
+        all interactive users have logged out, or in {}, whichever comes\n\
+        earlier. Please log out of all active sessions in order to let the auto-update\n\
+        process continue.",
         release_ver, time_till_reboot
     )
 }


### PR DESCRIPTION
Keep all lines to 80 characters.