### PR TITLE
actor: handle staging failures in a more graceful way

### DIFF
--- a/src/rpm_ostree/actor.rs
+++ b/src/rpm_ostree/actor.rs
@@ -107,27 +107,27 @@ impl Handler<QueryLocalDeployments> for RpmOstreeClient {
     }
 }
 
-/// Request: query pending deployment stream.
+/// Request: query pending deployment and stream.
 #[derive(Debug, Clone)]
 pub struct QueryPendingDeploymentStream {}
 
 impl Message for QueryPendingDeploymentStream {
-    type Result = Result<String>;
+    type Result = Result<Option<(Release, String)>>;
 }
 
 impl Handler<QueryPendingDeploymentStream> for RpmOstreeClient {
-    type Result = Result<String>;
+    type Result = Result<Option<(Release, String)>>;
 
     fn handle(
         &mut self,
         _msg: QueryPendingDeploymentStream,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        trace!("request to get OS update stream of pending deployment");
+        trace!("fetching details for staged deployment");
+
         let status = super::cli_status::invoke_cli_status(false)?;
-        let stream = super::cli_status::parse_pending_updates_stream(&status)
-            .context("failed to introspect OS updates stream of pending deployment")?;
-        Ok(stream)
+        super::cli_status::parse_pending_deployment(&status)
+            .context("failed to introspect pending deployment")
     }
 }
 

--- a/tests/kola/server/test-stream.sh
+++ b/tests/kola/server/test-stream.sh
@@ -90,7 +90,7 @@ EOF
     echo "updates.enabled = true" > /etc/zincati/config.d/99-test-status-updates-enabled.toml
     systemctl restart zincati.service
 
-    wait_journal_has_content "deployed an update on different update stream, abandoning update ${bad_version}"
+    wait_journal_has_content "abandoned and blocked deployment '${bad_version}'"
     ok "abandon update on different stream"
 
     wait_journal_has_content "Found 1 possible update target present in denylist; ignoring"


### PR DESCRIPTION
This tweaks the staging and introspection logic in order to be more
resilient to failures, and to handle temporary errors in a graceful way.
In particular, the update agent is now more conservative and only
marks a target update as blocked if it really observed a stream mismatch.

Ref: https://github.com/coreos/zincati/pull/622#pullrequestreview-758708050