### PR TITLE
cargo: enable debuginfo in the release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ failpoints = [ "fail/failpoints" ]
 
 [profile.release]
 lto = true
+# We assume we're being delivered via e.g. RPM which supports split debuginfo
+debug = true
 
 [package.metadata.release]
 disable-publish = true


### PR DESCRIPTION
related to https://github.com/coreos/afterburn/pull/625