### PR TITLE
docs: Small docs fixes

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,6 +5,11 @@ url: "https://coreos.github.io"
 # Comment above and use below for local development
 # url: "http://localhost:4000"
 permalink: /:title/
+markdown: kramdown
+kramdown:
+  typographic_symbols:
+    ndash: "--"
+    mdash: "---"
 
 remote_theme: coreos/just-the-docs
 plugins:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 nav_order: 9
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 nav_order: 3
 has_children: true
 ---

--- a/docs/development/agent-actor-system.md
+++ b/docs/development/agent-actor-system.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 nav_order: 2
 parent: Development
 ---

--- a/docs/development/cincinnati/protocol.md
+++ b/docs/development/cincinnati/protocol.md
@@ -2,7 +2,6 @@
 title: Cincinnati for Fedora CoreOS
 parent: Development
 nav_order: 3
-layout: default
 ---
 
 # Cincinnati for Fedora CoreOS

--- a/docs/development/fleetlock/protocol.md
+++ b/docs/development/fleetlock/protocol.md
@@ -1,7 +1,6 @@
 ---
 parent: Development
 nav_order: 4
-layout: default
 ---
 
 # FleetLock protocol

--- a/docs/development/os-metadata.md
+++ b/docs/development/os-metadata.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 nav_order: 5
 parent: Development
 ---

--- a/docs/development/quickstart.md
+++ b/docs/development/quickstart.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 nav_order: 1
 parent: Development
 ---

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 nav_order: 7
 parent: Development
 ---

--- a/docs/development/update-strategy-periodic.md
+++ b/docs/development/update-strategy-periodic.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 nav_order: 6
 parent: Development
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 nav_order: 1
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 nav_order: 2
 has_children: true
 ---

--- a/docs/usage/agent-identity.md
+++ b/docs/usage/agent-identity.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 parent: Usage
 ---
 

--- a/docs/usage/auto-updates.md
+++ b/docs/usage/auto-updates.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 parent: Usage
 ---
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 parent: Usage
 ---
 

--- a/docs/usage/logging.md
+++ b/docs/usage/logging.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 parent: Usage
 ---
 

--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 parent: Usage
 ---
 

--- a/docs/usage/updates-strategy.md
+++ b/docs/usage/updates-strategy.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 parent: Usage
 ---
 


### PR DESCRIPTION
docs: Do not convert -- & --- to en/em-dash

'--' is frequently used for command line options and was
thus\nincorrectly rendered as a special en-dash symbol.

---

docs: Remove default layout from front matter

No need to specify it as it is the default.