### PR TITLE
cargo: zincati release 0.0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.24-alpha.0"
+version = "0.0.24"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.24-alpha.0"
+version = "0.0.24"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
 * update_agent: handle staging failures in a more graceful way
 * update_agent: improve linewrapping of logout warning
 * update_agent: log finalization success
 * update_agent: log progress while waiting for the end of user sessions
 * update_agent: record a denylist in the state of update agent
 * update_agent: verify stream label on commit metadata before deploying
 * metrics: hard fail on socket cleanup errors
 * docs: small docs fixes
 * cargo: enable debuginfo in release profile
 * ci: bump linting toolchain to latest stable (1.56.0)