### PR TITLE
ci: bump toolchains

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ env:
   # Minimum supported Rust version (MSRV)
   ACTION_MSRV_TOOLCHAIN: 1.53.0
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.56.0
+  ACTION_LINTS_TOOLCHAIN: 1.58.0
 
 jobs:
   tests-stable:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.53.0
+  ACTION_MSRV_TOOLCHAIN: 1.57.0
   # Pinned toolchain for linting
   ACTION_LINTS_TOOLCHAIN: 1.58.0
 


### PR DESCRIPTION
This bumps CI toolchains:
 * lintings to 1.58 (latest stable)
 * MSRV to 1.57 (currently shipping in F35)