### PR TITLE
dist/systemd: add explicit ordering, after multi-user.target

### DIFF
--- a/dist/systemd/system/zincati.service
+++ b/dist/systemd/system/zincati.service
@@ -7,7 +7,7 @@ After=network.target
 # Wait for the boot to be marked as successful. In cluster contexts,
 # this prevents rolling out broken updates to all nodes in the fleet.
 Requires=boot-complete.target
-After=boot-complete.target
+After=multi-user.target boot-complete.target
 # Make sure we don't inadvertently reboot the system before a machine-id is
 # created so that we don't cause ConditionFirstBoot=true units to run twice
 # See discussions in https://github.com/systemd/systemd/issues/4511.


### PR DESCRIPTION
This tweaks the service unit ordering, adding explicit configuration for running after `multi-user.target`.
The service unit is currently pulled in by `multi-user.target`, which results in a implicit `Before` ordering being added by systemd. Unfortunately this may result in a dependency loop between `multi-user.target` and `boot-complete.target`, as the latter may need to start after the former.
Adding an explicit `After` statement here makes sure that both targets can be properly started in the relevant order, with Zincati queuing after both of them.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1298
Ref: https://lists.freedesktop.org/archives/systemd-devel/2022-September/048330.html