### PR TITLE
cargo: zincati release 0.0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.24"
+version = "0.0.25"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
 * cargo: bump to 2021 edition 
 * cargo: update all dependencies to latest versions
 * ci: bump toolchains
 * dist/systemd: add explicit ordering, after multi-user.target
 * tests/kola: re-arrange shared test helpers
