### PR TITLE
cli: port from structopt to clap-3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,15 +66,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,17 +281,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -709,12 +724,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1100,9 +1112,9 @@ checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "openssl"
-version = "0.10.41"
+version = "0.10.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1132,9 +1144,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
 dependencies = [
  "autocfg",
  "cc",
@@ -1162,6 +1174,12 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "parking"
@@ -1642,33 +1660,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -1678,9 +1672,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1712,27 +1706,24 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a99cb8c4b9a8ef0e7907cd3b617cc8dc04d571c4e73c8ae403d80ac160bb122"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a891860d3c8d66fec8e73ddb3765f90082374dbaaa833407b904a94f1a7eb43"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1909,18 +1900,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,12 +1935,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -2245,6 +2218,7 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "chrono",
+ "clap",
  "env_logger",
  "envsubst",
  "fail",
@@ -2270,7 +2244,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "structopt",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ actix = "0.13"
 anyhow = "1.0"
 cfg-if = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "3.2", features = ["cargo", "derive"] }
 env_logger = "0.9"
 envsubst = "0.2"
 fail = "0.5"
@@ -36,7 +37,6 @@ regex = "1.6"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-structopt = "0.3"
 tempfile = "^3.2"
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["signal", "rt", "rt-multi-thread"] }

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -4,9 +4,9 @@ use super::ensure_user;
 use crate::{config, dbus, metrics, rpm_ostree, update_agent, utils};
 use actix::Actor;
 use anyhow::{Context, Result};
+use clap::{crate_name, crate_version};
 use log::{info, trace};
 use prometheus::IntGauge;
-use structopt::clap::{crate_name, crate_version};
 use tokio::runtime::Runtime;
 
 lazy_static::lazy_static! {

--- a/src/cli/ex.rs
+++ b/src/cli/ex.rs
@@ -2,21 +2,21 @@
 
 use super::ensure_user;
 use anyhow::Result;
+use clap::Subcommand;
 use fn_error_context::context;
-use structopt::StructOpt;
 use zbus::dbus_proxy;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 pub enum Cmd {
     /// Replies different cow-speak depending on whether the
     /// talkative flag is set.
-    #[structopt(name = "moo")]
+    #[clap(name = "moo")]
     Moo {
-        #[structopt(long)]
+        #[clap(long)]
         talkative: bool,
     },
     /// Get last refresh time of update agent actor's state.
-    #[structopt(name = "last-refresh-time")]
+    #[clap(name = "last-refresh-time")]
     LastRefreshTime,
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,20 +5,19 @@ mod deadend;
 mod ex;
 
 use anyhow::Result;
+use clap::{AppSettings, Parser};
 use log::LevelFilter;
-use structopt::clap::AppSettings;
-use structopt::StructOpt;
 use users::get_current_username;
 
 /// CLI configuration options.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub(crate) struct CliOptions {
     /// Verbosity level (higher is more verbose).
-    #[structopt(short = "v", parse(from_occurrences), global = true)]
+    #[clap(short = 'v', parse(from_occurrences), global = true)]
     verbosity: u8,
 
     /// CLI sub-command.
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub(crate) cmd: CliCommand,
 }
 
@@ -44,16 +43,16 @@ impl CliOptions {
 }
 
 /// CLI sub-commands.
-#[derive(Debug, StructOpt)]
-#[structopt(rename_all = "kebab-case")]
+#[derive(Debug, Parser)]
+#[clap(rename_all = "kebab-case")]
 pub(crate) enum CliCommand {
     /// Long-running agent for auto-updates.
     Agent,
     /// Set or unset deadend MOTD state.
-    #[structopt(setting = AppSettings::Hidden)]
+    #[clap(subcommand, setting = AppSettings::Hidden)]
     DeadendMotd(deadend::Cmd),
     /// Print update agent state's last refresh time.
-    #[structopt(setting = AppSettings::Hidden)]
+    #[clap(subcommand, setting = AppSettings::Hidden)]
     Ex(ex::Cmd),
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,10 +16,10 @@ use crate::identity::Identity;
 use crate::strategy::UpdateStrategy;
 use crate::update_agent;
 use anyhow::Result;
+use clap::crate_name;
 use fn_error_context::context;
 use serde::Serialize;
 use std::num::NonZeroU64;
-use structopt::clap::crate_name;
 
 /// Runtime configuration for the agent.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,7 @@ mod utils;
 /// Logic for weekly maintenance windows.
 mod weekly;
 
-use structopt::clap::crate_name;
-use structopt::StructOpt;
+use clap::{crate_name, Parser};
 
 /// Binary entrypoint, for all CLI subcommands.
 fn main() {


### PR DESCRIPTION
This reworks CLI handling logic, porting from the legacy `structopt`
library to the recommended `clap` v3.

Fixes: https://github.com/coreos/zincati/issues/832