### PR TITLE
cli: stop using deprecated clap-v3 features

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,7 +5,7 @@ mod deadend;
 mod ex;
 
 use anyhow::Result;
-use clap::{AppSettings, Parser};
+use clap::{ArgAction, Parser};
 use log::LevelFilter;
 use users::get_current_username;
 
@@ -13,7 +13,7 @@ use users::get_current_username;
 #[derive(Debug, Parser)]
 pub(crate) struct CliOptions {
     /// Verbosity level (higher is more verbose).
-    #[clap(short = 'v', parse(from_occurrences), global = true)]
+    #[clap(action = ArgAction::Count, short = 'v', global = true)]
     verbosity: u8,
 
     /// CLI sub-command.
@@ -49,10 +49,10 @@ pub(crate) enum CliCommand {
     /// Long-running agent for auto-updates.
     Agent,
     /// Set or unset deadend MOTD state.
-    #[clap(subcommand, setting = AppSettings::Hidden)]
+    #[clap(hide = true, subcommand)]
     DeadendMotd(deadend::Cmd),
     /// Print update agent state's last refresh time.
-    #[clap(subcommand, setting = AppSettings::Hidden)]
+    #[clap(hide = true, subcommand)]
     Ex(ex::Cmd),
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
 /// Run till completion or failure, pretty-printing termination errors if any.
 fn run() -> i32 {
     // Parse command-line options.
-    let cli_opts = cli::CliOptions::from_args();
+    let cli_opts = cli::CliOptions::parse();
 
     // Setup logging.
     env_logger::Builder::from_default_env()


### PR DESCRIPTION
This tweaks CLI handling logic in order to avoid using deprecated clap-v3 primitives.
It should make a future v4 update more straightforward.