### PR TITLE
cli: stop using deprecated clap-v4 features

### DIFF
--- a/src/cli/deadend.rs
+++ b/src/cli/deadend.rs
@@ -17,13 +17,13 @@ static DEADEND_MOTD_PATH: &str = "/run/motd.d/85-zincati-deadend.motd";
 #[derive(Debug, Subcommand)]
 pub enum Cmd {
     /// Set deadend state, with given reason.
-    #[clap(name = "set")]
+    #[command(name = "set")]
     Set {
-        #[clap(long = "reason")]
+        #[arg(long = "reason")]
         reason: String,
     },
     /// Unset deadend state.
-    #[clap(name = "unset")]
+    #[command(name = "unset")]
     Unset,
 }
 

--- a/src/cli/ex.rs
+++ b/src/cli/ex.rs
@@ -10,13 +10,13 @@ use zbus::dbus_proxy;
 pub enum Cmd {
     /// Replies different cow-speak depending on whether the
     /// talkative flag is set.
-    #[clap(name = "moo")]
+    #[command(name = "moo")]
     Moo {
-        #[clap(long)]
+        #[arg(long)]
         talkative: bool,
     },
     /// Get last refresh time of update agent actor's state.
-    #[clap(name = "last-refresh-time")]
+    #[command(name = "last-refresh-time")]
     LastRefreshTime,
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,7 +13,7 @@ use users::get_current_username;
 #[derive(Debug, Parser)]
 pub(crate) struct CliOptions {
     /// Verbosity level (higher is more verbose).
-    #[clap(action = ArgAction::Count, short = 'v', global = true)]
+    #[arg(action = ArgAction::Count, short = 'v', global = true)]
     verbosity: u8,
 
     /// CLI sub-command.
@@ -44,15 +44,15 @@ impl CliOptions {
 
 /// CLI sub-commands.
 #[derive(Debug, Parser)]
-#[clap(rename_all = "kebab-case")]
+#[command(rename_all = "kebab-case")]
 pub(crate) enum CliCommand {
     /// Long-running agent for auto-updates.
     Agent,
     /// Set or unset deadend MOTD state.
-    #[clap(hide = true, subcommand)]
+    #[command(hide = true, subcommand)]
     DeadendMotd(deadend::Cmd),
     /// Print update agent state's last refresh time.
-    #[clap(hide = true, subcommand)]
+    #[command(hide = true, subcommand)]
     Ex(ex::Cmd),
 }
 


### PR DESCRIPTION
This tweaks CLI handling logic in order to avoid using deprecated clap-v4 primitives.
It should make a future v5 update more straightforward.