### PR TITLE
ci: migrate to new directory and method names

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -18,5 +18,5 @@ cosaPod(buildroot: true) {
     checkout scm
 
     unstash name: 'build'
-    fcosBuild(overlays: ["install"])
+    cosaBuild(overlays: ["install"])
 }


### PR DESCRIPTION
The previous `fcos*` ones are deprecated.
See: https://github.com/coreos/coreos-ci-lib/pull/122