### PR TITLE
Remove requirement for `coreos-assembler.basearch`

### DIFF
--- a/docs/development/os-metadata.md
+++ b/docs/development/os-metadata.md
@@ -30,7 +30,6 @@ Booted deployment must provide several mandatory metadata entries:
  * `checksum`: OSTree commit revision
  * `version`: OS version
  * under `base-commit-meta`:
-   * `coreos-assembler.basearch`: base architecture
    * `fedora-coreos.stream`: update stream
 
 All those metadata entries must exist with a non-empty string value.

--- a/src/rpm_ostree/cli_status.rs
+++ b/src/rpm_ostree/cli_status.rs
@@ -61,8 +61,6 @@ pub struct DeploymentJson {
 /// Metadata from base commit (only fields relevant to zincati).
 #[derive(Clone, Debug, Deserialize)]
 struct BaseCommitMetaJson {
-    #[serde(rename = "coreos-assembler.basearch")]
-    basearch: String,
     #[serde(rename = "fedora-coreos.stream")]
     stream: String,
 }
@@ -83,12 +81,6 @@ impl DeploymentJson {
             .clone()
             .unwrap_or_else(|| self.checksum.clone())
     }
-}
-
-/// Parse base architecture for booted deployment from status object.
-pub fn parse_basearch(status: &StatusJson) -> Result<String> {
-    let json = booted_json(status)?;
-    Ok(json.base_metadata.basearch)
 }
 
 /// Parse the booted deployment from status object.
@@ -157,7 +149,6 @@ fn booted_json(status: &StatusJson) -> Result<DeploymentJson> {
 
     ensure!(!booted.base_revision().is_empty(), "empty base revision");
     ensure!(!booted.version.is_empty(), "empty version");
-    ensure!(!booted.base_metadata.basearch.is_empty(), "empty basearch");
     Ok(booted)
 }
 
@@ -242,13 +233,6 @@ mod tests {
             let deployments = parse_local_deployments(&status, true);
             assert_eq!(deployments.len(), 1);
         }
-    }
-
-    #[test]
-    fn mock_booted_basearch() {
-        let status = mock_status("tests/fixtures/rpm-ostree-status.json").unwrap();
-        let booted = booted_json(&status).unwrap();
-        assert_eq!(booted.base_metadata.basearch, "x86_64");
     }
 
     #[test]

--- a/src/rpm_ostree/mod.rs
+++ b/src/rpm_ostree/mod.rs
@@ -1,9 +1,7 @@
 mod cli_deploy;
 mod cli_finalize;
 mod cli_status;
-pub use cli_status::{
-    invoke_cli_status, parse_basearch, parse_booted, parse_booted_updates_stream,
-};
+pub use cli_status::{invoke_cli_status, parse_booted, parse_booted_updates_stream};
 
 mod actor;
 pub use actor::{


### PR DESCRIPTION
This is aiming to increase compatibility of zincati with systems that aren't derived from Fedora CoreOS (e.g. IoT, desktop systems, etc.)

Additionally, even in the FCOS case, when one derives a container image from FCOS, the final build isn't generated by coreos-assembler and hence the ostree commit won't have this metadata.

In the end - I can't think of a use case for even trying to have zincati managing an image for a different architecture than the one it's compiled for.

So, copy the code I wrote for oci-spec-rs which maps from the Rust architecture to the GNU one.  xref
https://github.com/containers/oci-spec-rs/commit/52e450e631a212769df4dcd5b7904d942d246d24