### PR TITLE
build: Drop LTO by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ tempfile = "^3.2"
 failpoints = [ "fail/failpoints" ]
 
 [profile.release]
-lto = true
 # We assume we're being delivered via e.g. RPM which supports split debuginfo
 debug = true
 


### PR DESCRIPTION
Having `lto = true` came from the first git commit to this repository. I suspect it was copied from elsewhere.

Having this enabled here makes an incremental (`CARGO_INCREMENTAL=1`) one-line change build take over a minute.

Disabling it makes that same one-line change take a second.

I think in general we should be deferring decisions like this to "outer" buildsystems; e.g. in Fedora Koji it makes sense to opt-in to full LTO.