### PR TITLE
status: preparatory work for stream detection from container

### DIFF
--- a/src/weekly/utils.rs
+++ b/src/weekly/utils.rs
@@ -217,7 +217,7 @@ mod tests {
                 Err(_) => Duration::from_secs(1),
             };
             prop_assert!(res.as_secs() > 0);
-            prop_assert!((res.as_secs() / 60) < MAX_WEEKLY_MINS.into());
+            prop_assert!((res.as_secs() / 60) < u64::from(MAX_WEEKLY_MINS));
         }
 
         #[test]


### PR DESCRIPTION
utils: Use explicit `u64::from`

Prep for a PR which may pull in the `glib` crate which has
a conflicting impl for this conversion (which is likely a bug).

---

status: Add a helper to extract the stream

Prep for handling the container case in
https://github.com/coreos/zincati/pull/878

---

