### PR TITLE
identity: use stream metadata crate for architecture detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "coreos-stream-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5458d2e7e757f352484485c5f66285c81fe2676fd78e08b1ed76fdd6e72b61"
+dependencies = [
+ "serde",
+ "strum",
+ "strum_macros",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1485,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1678,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -2268,6 +2304,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "clap",
+ "coreos-stream-metadata",
  "env_logger",
  "envsubst",
  "fail",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0"
 cfg-if = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.0", features = ["cargo", "derive"] }
+coreos-stream-metadata = "0.1.0"
 env_logger = "0.9"
 envsubst = "0.2"
 fail = "0.5"

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -93,7 +93,7 @@ impl Identity {
     pub fn try_default() -> Result<Self> {
         // Invoke rpm-ostree to get the status of the currently booted deployment.
         let status = rpm_ostree::invoke_cli_status(true)?;
-        let basearch = crate::identity::current_architeture().to_string();
+        let basearch = coreos_stream_metadata::this_architecture().to_string();
         let current_os =
             rpm_ostree::parse_booted(&status).context("failed to introspect booted OS image")?;
         let node_uuid = {
@@ -187,17 +187,6 @@ fn compute_node_uuid(app_id: &id128::Id128) -> Result<id128::Id128> {
     let id = id128::get_machine_app_specific(app_id)
         .map_err(|e| anyhow!("failed to get node ID: {}", e))?;
     Ok(id)
-}
-
-// Translate the architecture we were compiled for to the
-// output from the `arch` command that is used for RPM and
-// coreos-assembler builds.
-pub(crate) fn current_architeture() -> &'static str {
-    match std::env::consts::ARCH {
-        "powerpc64" if cfg!(target_endian = "big") => "ppc64",
-        "powerpc64" if cfg!(target_endian = "little") => "ppc64le",
-        o => o,
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This drops our duplicate code for finding the process architecture.