### PR TITLE
service: exit and prevent restarts if booted into a container image

### DIFF
--- a/dist/systemd/system/zincati.service
+++ b/dist/systemd/system/zincati.service
@@ -21,6 +21,8 @@ Environment=ZINCATI_VERBOSITY="-v"
 Type=notify
 ExecStart=/usr/libexec/zincati agent ${ZINCATI_VERBOSITY}
 Restart=on-failure
+# This status signals a non-restartable condition
+RestartPreventExitStatus=7
 RestartSec=10s
 
 [Install]

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,20 +56,27 @@ fn run() -> i32 {
     match cli_opts.run() {
         Ok(_) => libc::EXIT_SUCCESS,
         Err(e) => {
-            log_error_chain(e);
-            libc::EXIT_FAILURE
+            log_error_chain(&e);
+            if e.root_cause()
+                .downcast_ref::<crate::rpm_ostree::FatalError>()
+                .is_some()
+            {
+                7
+            } else {
+                libc::EXIT_FAILURE
+            }
         }
     }
 }
 
 /// Pretty-print a chain of errors, as a series of error-priority log messages.
-fn log_error_chain(err_chain: anyhow::Error) {
+fn log_error_chain(err_chain: &anyhow::Error) {
     let mut chain_iter = err_chain.chain();
     let top_err = match chain_iter.next() {
         Some(e) => e.to_string(),
         None => "(unspecified failure)".to_string(),
     };
-    log::error!("critical error: {}", top_err);
+    log::error!("error: {}", top_err);
     for err in chain_iter {
         log::error!(" -> {}", err);
     }

--- a/src/rpm_ostree/mod.rs
+++ b/src/rpm_ostree/mod.rs
@@ -1,7 +1,7 @@
 mod cli_deploy;
 mod cli_finalize;
 mod cli_status;
-pub use cli_status::{invoke_cli_status, parse_booted, parse_booted_updates_stream};
+pub use cli_status::{invoke_cli_status, parse_booted, parse_booted_updates_stream, FatalError};
 
 mod actor;
 pub use actor::{


### PR DESCRIPTION
This is part of https://github.com/coreos/fedora-coreos-tracker/issues/1263

We don't yet have an official stance on how zincati and custom container images interact.  Today, zincati just crash loops. This changes things so that we gracefully exit if we detect the booted system is using a container image origin.

(The code here isn't quite as clean as it could be; calling
 `std::process::exit()` in the middle of the call chain isn't
  elegant but doing better would require plumbing through an
  `Option<T>` through many layers)