### PR TITLE
Simplify read paths

### DIFF
--- a/src/config/fragments.rs
+++ b/src/config/fragments.rs
@@ -99,14 +99,10 @@ pub(crate) struct UpdatePeriodicWindow {
 mod tests {
     use super::*;
     use maplit::btreeset;
-    use std::io::Read;
 
     #[test]
     fn basic_dist_config_sample() {
-        let fp = std::fs::File::open("tests/fixtures/00-config-sample.toml").unwrap();
-        let mut bufrd = std::io::BufReader::new(fp);
-        let mut content = vec![];
-        bufrd.read_to_end(&mut content).unwrap();
+        let content = std::fs::read("tests/fixtures/00-config-sample.toml").unwrap();
         let cfg: ConfigFragment = toml::from_slice(&content).unwrap();
 
         let expected = ConfigFragment {

--- a/src/config/inputs.rs
+++ b/src/config/inputs.rs
@@ -24,21 +24,14 @@ impl ConfigInput {
         common_path: &str,
         extensions: Vec<String>,
     ) -> Result<Self> {
-        use std::io::Read;
-
         let scanner = liboverdrop::FragmentScanner::new(dirs, common_path, true, extensions);
 
         let mut fragments = Vec::new();
         for (_, fpath) in scanner.scan() {
             trace!("reading config fragment '{}'", fpath.display());
 
-            let fp = std::fs::File::open(&fpath)
-                .with_context(|| format!("failed to open file '{}'", fpath.display()))?;
-            let mut bufrd = std::io::BufReader::new(fp);
-            let mut content = vec![];
-            bufrd
-                .read_to_end(&mut content)
-                .with_context(|| format!("failed to read content of '{}'", fpath.display()))?;
+            let content = std::fs::read(&fpath)
+                .with_context(|| format!("failed to read file '{}'", fpath.display()))?;
             let frag: fragments::ConfigFragment =
                 toml::from_slice(&content).context("failed to parse TOML")?;
 

--- a/src/identity/platform.rs
+++ b/src/identity/platform.rs
@@ -7,8 +7,6 @@
 //!  https://github.com/coreos/afterburn/blob/v4.1.0/src/util/cmdline.rs
 
 use anyhow::{Context, Result};
-use std::io::Read;
-use std::{fs, io};
 
 /// Platform key.
 static CMDLINE_PLATFORM_FLAG: &str = "ignition.platform.id";
@@ -18,16 +16,8 @@ pub(crate) fn read_id<T>(cmdline_path: T) -> Result<String>
 where
     T: AsRef<str>,
 {
-    // open the cmdline file
     let fpath = cmdline_path.as_ref();
-    let file =
-        fs::File::open(fpath).with_context(|| format!("failed to open cmdline file {}", fpath))?;
-
-    // read content
-    let mut bufrd = io::BufReader::new(file);
-    let mut contents = String::new();
-    bufrd
-        .read_to_string(&mut contents)
+    let contents = std::fs::read_to_string(fpath)
         .with_context(|| format!("failed to read cmdline file {}", fpath))?;
 
     // lookup flag by key name

--- a/src/rpm_ostree/cli_status.rs
+++ b/src/rpm_ostree/cli_status.rs
@@ -236,10 +236,8 @@ mod tests {
     use super::*;
 
     fn mock_status(path: &str) -> Result<StatusJson> {
-        let fp = std::fs::File::open(path).unwrap();
-        let bufrd = std::io::BufReader::new(fp);
-        let status: StatusJson = serde_json::from_reader(bufrd)?;
-        Ok(status)
+        let r = std::fs::File::open(path).map(std::io::BufReader::new)?;
+        Ok(serde_json::from_reader(r)?)
     }
 
     #[test]

--- a/src/strategy/periodic.rs
+++ b/src/strategy/periodic.rs
@@ -190,7 +190,6 @@ impl StrategyPeriodic {
 mod tests {
     use super::*;
     use crate::config::{fragments, inputs};
-    use std::io::Read;
     use tokio::runtime as rt;
 
     #[test]
@@ -301,10 +300,7 @@ mod tests {
     }
 
     fn parse_config_input(config_path: &str) -> inputs::ConfigInput {
-        let fp = std::fs::File::open(config_path).unwrap();
-        let mut bufrd = std::io::BufReader::new(fp);
-        let mut content = vec![];
-        bufrd.read_to_end(&mut content).unwrap();
+        let content = std::fs::read(config_path).unwrap();
         let frag: fragments::ConfigFragment = toml::from_slice(&content).unwrap();
         inputs::ConfigInput::merge_fragments(vec![frag])
     }


### PR DESCRIPTION
Use the `std::fs` functions to read to a string or `Vec<u8>` directly; it's more efficient and less code.

Also in one place use `.map(BufReader::new)` which I find more... readable.

Not prep for anything, just a drive-by change since I was reading the code for other reasons.