### PR TITLE
Drop "Json" suffix from rpm-ostree types

### DIFF
--- a/src/rpm_ostree/actor.rs
+++ b/src/rpm_ostree/actor.rs
@@ -1,6 +1,6 @@
 //! rpm-ostree client actor.
 
-use super::cli_status::StatusJson;
+use super::cli_status::Status;
 use super::Release;
 use actix::prelude::*;
 use anyhow::{Context, Result};
@@ -12,7 +12,7 @@ use std::rc::Rc;
 /// Cache of local deployments.
 #[derive(Clone, Debug)]
 pub struct StatusCache {
-    pub status: Rc<StatusJson>,
+    pub status: Rc<Status>,
     pub mtime: FileTime,
 }
 


### PR DESCRIPTION
The fact that we parsed this from JSON is just an implementation detail.