### PR TITLE
cargo: add configuration for cargo-vendor-filterer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,12 @@ pre-release-commit-message = "cargo: zincati release {{version}}"
 sign-commit = true
 sign-tag = true
 tag-message = "zincati {{version}}"
+
+# See https://github.com/coreos/cargo-vendor-filterer
+[package.metadata.vendor-filter]
+# cargo-vendor-filterer supports wildcards but requires some degree of LLVM
+# support for every matching platform, which isn't necessarily available
+# out of the box.  Use this as a stand-in.  Note that architecture-specific
+# crate dependencies (apart from wasm32) are uncommon in the ecosystem.
+platforms = ["x86_64-unknown-linux-gnu"]
+all-features = true


### PR DESCRIPTION
See https://github.com/coreos/cargo-vendor-filterer.

This project only targets Linux so we don't need any other platform dependencies.  Notably this obsoletes the manual step to strip all the static library files for the Windows crates.

```
$ find vendor-old -name '*.a' -delete
$ du -sh vendor-old vendor-new
208M	vendor-old
76M	vendor-new
```