### PR TITLE
docs: Remove Travis-CI badge & Use upstream theme & update to 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Zincati
 
-![Checks status](https://img.shields.io/github/checks-status/coreos/zincati/main)
 [![crates.io](https://img.shields.io/crates/v/zincati.svg)](https://crates.io/crates/zincati)
 
 Zincati is an auto-update agent for Fedora CoreOS hosts.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,7 +11,7 @@ kramdown:
     ndash: "--"
     mdash: "---"
 
-remote_theme: coreos/just-the-docs
+remote_theme: just-the-docs/just-the-docs@v0.4.1
 plugins:
   - jekyll-remote-theme
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,6 @@ nav_order: 1
 
 # Zincati
 
-[![Build status](https://travis-ci.org/coreos/zincati.svg?branch=main)](https://travis-ci.org/coreos/zincati)
 [![crates.io](https://img.shields.io/crates/v/zincati.svg)](https://crates.io/crates/zincati)
 
 Zincati is an auto-update agent for Fedora CoreOS hosts.


### PR DESCRIPTION
README & docs index: Remove Travis-CI badge

---

docs: Use upstream theme & update to 0.4.1

Use a fixed tag for the theme so that we can directly pull it from
upstream and skip vendoring the theme in the coreos org.