### PR TITLE
sysusers.d/50-zincati.conf: tweak comments

### DIFF
--- a/dist/sysusers.d/50-zincati.conf
+++ b/dist/sysusers.d/50-zincati.conf
@@ -1,3 +1,3 @@
-#Zincati - https://github.com/coreos/zincati
-#Type  Name     ID  GECOS
+# Zincati - https://github.com/coreos/zincati
+# Type  Name     ID  GECOS
 u      zincati  -   "Zincati user for auto-updates"


### PR DESCRIPTION
The sysusers docs say that lines starting with `#` are ignored, but I think there's RPM macros or something that trip up on this:

    error: lua script failed: [string "add_sysuser"]:16: invalid sysuser type: #Zincati
      3<        (%lua)
      2<      (%add_sysuser)
    error: lua script failed: [string "add_sysuser"]:16: invalid sysuser type: #Type
      3<        (%lua)
      2<      (%add_sysuser)

And systemd's sysusers dropins all also seem to have a space separator.

Let's add a space to see if it helps.