### PR TITLE
Just exit normally when booted into a container

### DIFF
--- a/dist/systemd/system/zincati.service
+++ b/dist/systemd/system/zincati.service
@@ -21,8 +21,6 @@ Environment=ZINCATI_VERBOSITY="-v"
 Type=notify
 ExecStart=/usr/libexec/zincati agent ${ZINCATI_VERBOSITY}
 Restart=on-failure
-# This status signals a non-restartable condition
-RestartPreventExitStatus=7
 RestartSec=10s
 
 [Install]

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,10 +58,10 @@ fn run() -> i32 {
         Err(e) => {
             log_error_chain(&e);
             if e.root_cause()
-                .downcast_ref::<crate::rpm_ostree::FatalError>()
+                .downcast_ref::<crate::rpm_ostree::SystemInoperable>()
                 .is_some()
             {
-                7
+                0
             } else {
                 libc::EXIT_FAILURE
             }

--- a/src/rpm_ostree/mod.rs
+++ b/src/rpm_ostree/mod.rs
@@ -1,7 +1,9 @@
 mod cli_deploy;
 mod cli_finalize;
 mod cli_status;
-pub use cli_status::{invoke_cli_status, parse_booted, parse_booted_updates_stream, FatalError};
+pub use cli_status::{
+    invoke_cli_status, parse_booted, parse_booted_updates_stream, SystemInoperable,
+};
 
 mod actor;
 pub use actor::{


### PR DESCRIPTION
The previous work resulted in an error, but let's just exit with status zero because otherwise we end up tripping up things like checks for failing units.

Anyone who has rebased into a container has very clearly taken explicit control over the wheel and there's no point in us erroring out.
