### PR TITLE
zincati.service: periodically restart zincati daemon

### DIFF
--- a/dist/systemd/system/zincati.service
+++ b/dist/systemd/system/zincati.service
@@ -22,6 +22,7 @@ Type=notify
 ExecStart=/usr/libexec/zincati agent ${ZINCATI_VERBOSITY}
 Restart=on-failure
 RestartSec=10s
+RuntimeMaxSec=3w
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We've seen some issues in the past where a simple restart of the zincati daemon would have allowed systems to continue updating. Let's periodically restart the zincati daemon to handle cases like this in the future, which we can't always foresee.

The most recent example being: https://github.com/coreos/fedora-coreos-tracker/issues/1608