### PR TITLE
cargo: zincati release 0.0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.27"
+version = "0.0.28"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
- ci: cancel previous build on PR update
- packit: add initial support
- cargo: update all dependencies to latest versions