### PR TITLE
Add the action `prepare_files` to generate the new rpm file

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,10 +1,12 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 actions:
-    changelog-entry:
-        - bash -c 'echo "- New upstream release"'
-    post-upstream-clone:
-        - wget https://src.fedoraproject.org/rpms/rust-zincati/raw/rawhide/f/rust-zincati.spec
+  changelog-entry:
+    - bash -c 'echo "- New upstream release"'
+  post-upstream-clone:
+    - wget https://src.fedoraproject.org/rpms/rust-zincati/raw/rawhide/f/rust-zincati.spec
+  prepare-files:
+    - bash -c 'rust2rpm -s zincati $PACKIT_PROJECT_VERSION'
 
 specfile_path: rust-zincati.spec
 downstream_package_name: rust-zincati


### PR DESCRIPTION
As workaround for the issue that rust and packit are not currently compatible.
Xerf to https://src.fedoraproject.org/rpms/rust-openssh-keys/pull-request/9 and https://issues.redhat.com/browse/COS-2776