### PR TITLE
cargo: zincati release 0.0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.28"
+version = "0.0.29"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
- cargo: update all dependencies to latest versions
- Add the action `prepare_files` to generate the new rpm file