### PR TITLE
Add new `zincati-update-now` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ install: build
 	install -D -m 644 -t ${DESTDIR}/usr/share/polkit-1/rules.d dist/polkit-1/rules.d/*.rules
 	install -D -m 644 -t ${DESTDIR}/usr/share/polkit-1/actions dist/polkit-1/actions/*.policy
 	install -D -m 644 -t ${DESTDIR}/usr/share/dbus-1/system.d dist/dbus-1/system.d/*.conf
+	install -D -m 644 -t ${DESTDIR}/usr/bin dist/bin/*
 
 .PHONY: check
 check:

--- a/dist/bin/zincati-update-now
+++ b/dist/bin/zincati-update-now
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "WARN: This command is experimental and subject to change." >&2
+
+# this should exist already, but in case
+mkdir -p /run/zincati/config.d
+cat > /run/zincati/config.d/99-update-now.toml << EOF
+[identity]
+rollout_wariness = 0.0
+[updates]
+strategy = "immediate"
+EOF
+
+touch /run/zincati/override-interactive-check
+
+systemctl daemon-reload
+systemctl restart zincati
+
+echo "INFO: Streaming Zincati and RPM-OSTree logs..." >&2
+exec journalctl -f -u zincati -u rpm-ostreed


### PR DESCRIPTION
This addresses the gap identified in
https://github.com/coreos/zincati/issues/498 in a blunt way by setting some runtime config knobs so Zincati in effect immediately downloads, deploys, and reboots the system.

The motivation to at least have this for now is
https://github.com/coreos/zincati/pull/1241, which will purposely break `rpm-ostree upgrade --bypass-driver`. But clearly the approach here is applicable regardless of whether the node has switched to OCI.

In the future, this may either get replaced by a proper `zincatictl` entrypoint, or by better integration into the system's update tooling (e.g. bootc), so that `bootc upgrade` does the right thing.