### PR TITLE
tests/kola/experimental: fix LastRefreshTime method name

### DIFF
--- a/tests/kola/dbus/test-experimental.sh
+++ b/tests/kola/dbus/test-experimental.sh
@@ -9,7 +9,7 @@ set -xeuo pipefail
 cd $(mktemp -d)
 
 # Ensure that methods in this interface can only be called by root.
-if sudo -u core busctl call org.coreos.zincati /org/coreos/zincati org.coreos.zincati.Experimental LastRefresh 2> err.txt; then
+if sudo -u core busctl call org.coreos.zincati /org/coreos/zincati org.coreos.zincati.Experimental LastRefreshTime 2> err.txt; then
   fatal "Non-root user calling Experimental interface unexpectedly succeeded"
 fi
 assert_file_has_content err.txt "Access denied"


### PR DESCRIPTION
We were using the wrong method name here.

Likely fixes https://github.com/coreos/zincati/issues/1176.

(E.g. maybe what happened there is that previously zbus would return "Access denied" for unauthorized users even for non-existent methods and maybe the logic changed so the existence check was done first.)