### PR TITLE
Fixed minute format in periodic update log

### DIFF
--- a/src/strategy/periodic.rs
+++ b/src/strategy/periodic.rs
@@ -132,7 +132,7 @@ impl StrategyPeriodic {
             Some(minute_in_week) => {
                 let (weekday, hour, minute) = utils::weekly_minute_as_weekday_time(minute_in_week);
                 format!(
-                    "at {}:{} on {} ({}), subject to time zone caveats.",
+                    "at {}:{:0>2} on {} ({}), subject to time zone caveats.",
                     hour, minute, weekday, self.tz_name
                 )
             }


### PR DESCRIPTION
The log message reporting when the next update window is for the 'periodic' strategy does not format the minute nicely.  For instance, an update scheduled for `2:00` appears instead as `2:0` in the log, which may make new users think something is configured wrong.  This PR simply zero-pads the minute to ensure two digits are always displayed.