### PR TITLE
quality of life improvements for zincati-update-now

### DIFF
--- a/dist/bin/zincati-update-now
+++ b/dist/bin/zincati-update-now
@@ -23,4 +23,4 @@ systemctl daemon-reload
 systemctl restart zincati --no-block
 
 echo "INFO: Streaming Zincati and RPM-OSTree logs..." >&2
-exec journalctl -f -u zincati -u rpm-ostreed
+exec journalctl -f -u zincati -u rpm-ostreed --since now

--- a/dist/bin/zincati-update-now
+++ b/dist/bin/zincati-update-now
@@ -20,7 +20,7 @@ EOF
 touch /run/zincati/override-interactive-check
 
 systemctl daemon-reload
-systemctl restart zincati
+systemctl restart zincati --no-block
 
 echo "INFO: Streaming Zincati and RPM-OSTree logs..." >&2
 exec journalctl -f -u zincati -u rpm-ostreed

--- a/dist/bin/zincati-update-now
+++ b/dist/bin/zincati-update-now
@@ -3,6 +3,11 @@ set -euo pipefail
 
 echo "WARN: This command is experimental and subject to change." >&2
 
+if [ "$EUID" != "0" ]; then
+    echo "ERROR: Must be root to run zincati-update-now" >&2
+    exit 1
+fi
+
 # this should exist already, but in case
 mkdir -p /run/zincati/config.d
 cat > /run/zincati/config.d/99-update-now.toml << EOF


### PR DESCRIPTION

    zincati-update-now: limit journal messages
    
    The `-f` will show 10 previous lines which include some lines from
    the previous instance of zincati. Let's just limit the messages to
    the ones from this point forward.

---

    zincati-update-now: don't block when restarting zincati
    
    This allows us to more quickly fall through to the `journalctl`
    following. I hit a case where it was taking some time for the
    restart operation to complete (zincati was crashlooping) and
    it would have helped to have already fallen through to the
    journal watching.

---

    zincati-update-now: give good error message when run without privs
    
    This is a bit better than what currently happens.

