### PR TITLE
cargo: zincati release 0.0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "zincati"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zincati"
-version = "0.0.29"
+version = "0.0.30"
 description = "Update agent for Fedora CoreOS"
 homepage = "https://coreos.github.io/zincati"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes:
-  Polkit rule fix [GHSA-w6fv-6gcc-x825](https://github.com/coreos/zincati/security/advisories/GHSA-w6fv-6gcc-x825)  [01d8e89]
-  MSRV bumped to 1.84.1 [7b2fe3e]
-  Add support for local OCI deployments [5168f08]
-  Support updating using OCI graph [a8f3fe6]
-  Minute formatting updated to correctly show minutes in update log [07aa993]
-  Add status override for 'cli_status' [07aa993]
-  No longer block on zincati when reloading zincati [5ccf48c] 
-  Clamp journal messages to current instance 'zincati-update-now' [8d307d5]


https://github.com/coreos/zincati/issues/1269