### PR TITLE
cincinnati: fix updates nodes comparison logic

### DIFF
--- a/src/cincinnati/mod.rs
+++ b/src/cincinnati/mod.rs
@@ -319,11 +319,14 @@ fn find_update(
 
 /// Try to match a set of (denylisted) deployments to their graph entries.
 fn find_denylisted_releases(graph: &client::Graph, depls: BTreeSet<Release>) -> BTreeSet<Release> {
+    use std::collections::HashSet;
+
     let mut local_releases = BTreeSet::new();
+    let local_payloads: HashSet<Payload> = depls.into_iter().map(|rel| rel.payload).collect();
 
     for entry in &graph.nodes {
         if let Ok(release) = Release::from_cincinnati(entry.clone()) {
-            if depls.contains(&release) {
+            if local_payloads.contains(&release.payload) {
                 local_releases.insert(release);
             }
         }


### PR DESCRIPTION
In [1] i reworked how cincinnati nodes are turned into deployments for comparing them. I also simplified this logic to match already existing deployments with cincinnati nodes.

Basically the cincinnati node is turned into a deployment looking like:
```
Release {
    version: "42.20250410.3.1",
    payload: Checksum("e057a84658cd114c1fa8a944d8fe3de93f5413c0fbe3f1fabc737cc04bbd749b"),
    age_index: Some(144) }
```

And a local deployment looks like:
```
Release {
    version: "41.20250315.3.0",
    payload: Checksum("3c6418b40e2c7fe4605ff1fa744a845caadd50e10bd31aab14e059b529f49c98"),
    age_index: None }
```

Obviously, there is no age_index value for a local deployement as it's a cinncinati thing. Thus, a local deployment won't ever be equal to a cinncinati node.

Fix thi slogic by extracting the `Payload` enum and comparing those, as this is either a pullspec or an ostree checksum they will match. Which is was the original code was doing anyway.

[1] https://github.com/coreos/zincati/commit/ea83496bdaa8d438e83fb8d555299fdb4f46753d

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1938