### PR TITLE
systemd: Add condition to only run on ostree systems

### DIFF
--- a/dist/systemd/system/zincati.service
+++ b/dist/systemd/system/zincati.service
@@ -3,6 +3,9 @@ Description=Zincati Update Agent
 Documentation=https://github.com/coreos/zincati
 # Skip live systems not meant to be auto-updated (e.g. live PXE, live ISO)
 ConditionPathExists=!/run/ostree-live
+# This ensures compatibility with `bcvk ephemeral` today; compatibility
+# with a bootc+composefs future is still TBD.
+ConditionKernelCommandLine=ostree
 After=network.target
 # Wait for the boot to be marked as successful. In cluster contexts,
 # this prevents rolling out broken updates to all nodes in the fleet.


### PR DESCRIPTION
Add ConditionKernelCommandLine=ostree to prevent zincati from running on systems that aren't using ostree, where the update agent wouldn't be applicable.

This is motivated by having the service not run in `bcvk ephemeral` as well as `podman run /sbin/init`.