### PR TITLE
Cargo: add socks feature to reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ ostree-ext = "0.15.3"
 prometheus = { version = "0.14", default-features = false }
 rand = ">=0.9, < 0.10"
 regex = "1.12"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "socks"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = ">= 3.7, < 4.0"


### PR DESCRIPTION
Add SOCKS5 support to Zincati by enabling the appropriate feature flag for the reqwest dependency. Reqwest should pull in the proxy config from the environment.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/2067